### PR TITLE
feat: add support for @pytest_asyncio.fixture decorator

### DIFF
--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -5,13 +5,14 @@
 
 use rustpython_parser::ast::Expr;
 
-/// Check if an expression is a @pytest.fixture decorator
+/// Check if an expression is a @pytest.fixture or @pytest_asyncio.fixture decorator
 pub fn is_fixture_decorator(expr: &Expr) -> bool {
     match expr {
         Expr::Name(name) => name.id.as_str() == "fixture",
         Expr::Attribute(attr) => {
             if let Expr::Name(value) = &*attr.value {
-                value.id.as_str() == "pytest" && attr.attr.as_str() == "fixture"
+                (value.id.as_str() == "pytest" || value.id.as_str() == "pytest_asyncio")
+                    && attr.attr.as_str() == "fixture"
             } else {
                 false
             }

--- a/tests/test_decorators.rs
+++ b/tests/test_decorators.rs
@@ -53,6 +53,38 @@ fn test_is_fixture_decorator_with_args() {
 
 #[test]
 #[timeout(30000)]
+fn test_is_fixture_decorator_pytest_asyncio() {
+    // Test @pytest_asyncio.fixture (no parens)
+    let code = "@pytest_asyncio.fixture\nasync def my_fixture(): pass";
+    let parsed = parse(code, Mode::Module, "").unwrap();
+
+    if let rustpython_parser::ast::Mod::Module(module) = parsed {
+        if let rustpython_parser::ast::Stmt::AsyncFunctionDef(func_def) = &module.body[0] {
+            assert!(decorators::is_fixture_decorator(
+                &func_def.decorator_list[0]
+            ));
+        }
+    }
+}
+
+#[test]
+#[timeout(30000)]
+fn test_is_fixture_decorator_pytest_asyncio_with_args() {
+    // Test @pytest_asyncio.fixture(scope='session')
+    let code = "@pytest_asyncio.fixture(scope='session')\nasync def my_fixture(): pass";
+    let parsed = parse(code, Mode::Module, "").unwrap();
+
+    if let rustpython_parser::ast::Mod::Module(module) = parsed {
+        if let rustpython_parser::ast::Stmt::AsyncFunctionDef(func_def) = &module.body[0] {
+            assert!(decorators::is_fixture_decorator(
+                &func_def.decorator_list[0]
+            ));
+        }
+    }
+}
+
+#[test]
+#[timeout(30000)]
 fn test_not_fixture_decorator() {
     let code = "@property\ndef my_prop(): pass";
     let parsed = parse(code, Mode::Module, "").unwrap();

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -3277,15 +3277,13 @@ async def regular_async_fixture():
     let file_path = PathBuf::from("/tmp/test/conftest.py");
     db.analyze_file(file_path.clone(), content);
 
-    // Currently, @pytest_asyncio.fixture is NOT detected (limitation)
-    // Only @pytest.fixture and bare @fixture are supported
-    // See src/fixtures.rs:653 is_fixture_decorator()
+    // @pytest_asyncio.fixture is now supported
     assert!(
-        !db.definitions.contains_key("async_fixture"),
-        "pytest_asyncio.fixture not currently supported - this is a known limitation"
+        db.definitions.contains_key("async_fixture"),
+        "pytest_asyncio.fixture should be detected"
     );
 
-    // Regular async fixtures with @pytest.fixture ARE detected
+    // Regular async fixtures with @pytest.fixture are also detected
     assert!(db.definitions.contains_key("regular_async_fixture"));
 }
 


### PR DESCRIPTION
## What
Adds support for `@pytest_asyncio.fixture` decorator recognition.

## Why
Fixtures decorated with `@pytest_asyncio.fixture` were not being detected, making go-to-definition, find-references, hover, and completion unavailable for async fixtures from the [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio) plugin.

## How
Extended `is_fixture_decorator()` to recognize `pytest_asyncio` as a valid module name alongside `pytest`.

### Supported patterns
- `@pytest_asyncio.fixture`
- `@pytest_asyncio.fixture()`
- `@pytest_asyncio.fixture(...)` with any arguments (scope, autouse, name, etc.)

### Limitations
This is a targeted fix for `pytest_asyncio` specifically. Other third-party fixture decorators (e.g., `pytest_trio.fixture`) would need similar additions. A more generic approach (accepting any `*.fixture`) was considered but rejected to avoid false positives.

## Testing
- 2 new unit tests added
- All 339 tests pass