### PR TITLE
fix: resolve dependabot label warnings and deprecation notice

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "rust"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -36,10 +33,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "rust"
-      - "zed-extension"
     commit-message:
       prefix: "deps(zed)"
       include: "scope"
@@ -55,10 +48,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "javascript"
-      - "vscode-extension"
     commit-message:
       prefix: "deps(vscode)"
       include: "scope"
@@ -81,10 +70,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "kotlin"
-      - "intellij-plugin"
     commit-message:
       prefix: "deps(intellij)"
       include: "scope"
@@ -100,9 +85,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "python"
     commit-message:
       prefix: "deps(python)"
       include: "scope"
@@ -118,9 +100,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "bellini666"
-    labels:
-      - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -5,9 +5,21 @@ fail_on_severity: moderate
 
 license_check: true
 
-deny_licenses:
-  - GPL-3.0
-  - LGPL-3.0
-  - AGPL-3.0
+allow_licenses:
+  - MIT
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - MPL-2.0
+  - Unlicense
+  - 0BSD
+  - CC0-1.0
+  - Zlib
+  - CC-BY-4.0
+  - Python-2.0
+  - Unicode-3.0
+  - Unicode-DFS-2016
+  - BSL-1.0
 
 comment_summary_in_pr: always


### PR DESCRIPTION
## Summary
- Remove non-existent labels from dependabot.yml (fixes "Labels not found" warning)
- Switch from deprecated `deny_licenses` to `allow_licenses` in dependency-review-config.yml (fixes deprecation warning for v5.x compatibility)