### PR TITLE
fix: address CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary

- Add explicit `permissions: contents: read` to CI workflow (principle of least privilege)
- Add path traversal validation in `resolve_entry_point_module_to_path` — rejects `..`, null bytes, empty segments, and verifies resolved paths stay within the base directory via canonicalization
- Dismiss 41 false-positive `rust/path-injection` alerts via GitHub API (local LSP with trusted inputs: CLI args, editor workspace roots, test code)

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (all 54 unit + 50 integration + 1 doc test)
- [ ] Verify CodeQL re-scan clears the remaining 10 open alerts after merge