### PR TITLE
ci: publish VSCode extension to Open VSX Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,6 +403,42 @@ jobs:
           cd extensions/vscode-extension
           vsce publish -p ${{ secrets.VSCE_TOKEN }}
 
+  publish-openvsx:
+    name: Publish to Open VSX Registry
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [build-binaries]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Download all binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: binary-*
+          path: extensions/vscode-extension/bin
+      - name: Flatten binaries
+        run: |
+          cd extensions/vscode-extension/bin
+          find . -type f -name "pytest-language-server*" -exec mv {} . \;
+          find . -type d -empty -delete
+          chmod +x pytest-language-server-* || true
+          ls -lh
+      - name: Install dependencies
+        run: |
+          cd extensions/vscode-extension
+          npm install
+          npm install -g @vscode/vsce ovsx
+      - name: Package extension
+        run: |
+          cd extensions/vscode-extension
+          vsce package
+      - name: Publish to Open VSX Registry
+        run: |
+          cd extensions/vscode-extension
+          ovsx publish -p ${{ secrets.OVSX_TOKEN }}
+
   publish-intellij:
     name: Publish IntelliJ/PyCharm plugin
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -368,7 +368,8 @@ After installing the extension, you need to enable the language server for Pytho
 
 **The extension includes pre-built binaries - no separate installation required!**
 
-Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bellini666.pytest-language-server):
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bellini666.pytest-language-server)
+or the [Open VSX Registry](https://open-vsx.org/extension/bellini666/pytest-language-server) (for VSCodium, Cursor, Windsurf, etc.):
 
 1. Open VS Code
 2. Go to Extensions (Cmd+Shift+X / Ctrl+Shift+X)

--- a/README.md
+++ b/README.md
@@ -368,8 +368,7 @@ After installing the extension, you need to enable the language server for Pytho
 
 **The extension includes pre-built binaries - no separate installation required!**
 
-Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bellini666.pytest-language-server)
-or the [Open VSX Registry](https://open-vsx.org/extension/bellini666/pytest-language-server) (for VSCodium, Cursor, Windsurf, etc.):
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bellini666.pytest-language-server) or the [Open VSX Registry](https://open-vsx.org/extension/bellini666/pytest-language-server) (for VSCodium, Cursor, Windsurf, etc.):
 
 1. Open VS Code
 2. Go to Extensions (Cmd+Shift+X / Ctrl+Shift+X)


### PR DESCRIPTION
Fix #140

## Summary

- Adds a `publish-openvsx` job in `.github/workflows/release.yml` that mirrors `publish-vscode`: same tag trigger, same `needs: [build-binaries]`, repackages the extension and runs `ovsx publish -p $OVSX_TOKEN`. Future tagged releases auto-publish to both the VSCode Marketplace and Open VSX.
- Links the Open VSX listing from the VS Code install section of the top-level README so VSCodium / Cursor / Windsurf users can find it.

v0.22.0 has already been published manually to bootstrap the namespace: https://open-vsx.org/extension/bellini666/pytest-language-server

## One-time setup required before the next release

1. Claim the `bellini666` namespace on Open VSX (issue filed at EclipseFdn/open-vsx.org — manual approval).
2. Generate an Open VSX PAT and add it as repo secret `OVSX_TOKEN`.

Without `OVSX_TOKEN` the new job will fail on the publish step; the `publish-vscode` job is unaffected.

## Test plan

- [ ] Next tagged release runs `publish-openvsx` in parallel with `publish-vscode` and both succeed.
- [ ] The new version appears at https://open-vsx.org/extension/bellini666/pytest-language-server within ~1 min of job completion.