### PR TITLE
fix: skip chmod when binary is already executable

### DIFF
--- a/extensions/vscode-extension/src/extension.ts
+++ b/extensions/vscode-extension/src/extension.ts
@@ -59,7 +59,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }
     // Make sure it's executable on Unix-like systems
     if (process.platform !== 'win32') {
-      fs.chmodSync(command, 0o755);
+      try {
+        fs.accessSync(command, fs.constants.X_OK);
+      } catch {
+        fs.chmodSync(command, 0o755);
+      }
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Hi!

When I am installing this extension in my setup (I am using NixOS) the chmod fails with `EROFS` because the binary is on a read-only file system (the Nix store). The binary already has the executable bit set from the build step, so the `chmod` isn't actually needed, but the error causes the extension to bail out entirely without starting the language server.

My current workaround is: create a one-liner shell script on a mutable filesystem that re-execs the original binary, and point `pytestLanguageServer.executable` vscode config to that script.

Please note that I am not that familiar with javascript/typescript, but I did a minimal reproduction and it looks like working.

Feel free to edit or even drop this PR.