### PR TITLE
fix: drop internal PluginManagerCore.getPlugin usage in IntelliJ plugin

### DIFF
--- a/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLanguageServerService.kt
+++ b/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLanguageServerService.kt
@@ -1,9 +1,8 @@
 package com.github.bellini666.pytestlsp
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
@@ -105,9 +104,9 @@ class PytestLanguageServerService(private val project: Project) {
             }
         }
 
-        // Get plugin directory using IntelliJ's plugin API
-        val pluginId = PluginId.getId("com.github.bellini666.pytest-language-server")
-        val pluginDescriptor = PluginManagerCore.getPlugin(pluginId)
+        // Resolve the plugin directory via this plugin's own classloader, which exposes a
+        // stable PluginDescriptor without the now-internal PluginManagerCore.getPlugin().
+        val pluginDescriptor = (javaClass.classLoader as? PluginAwareClassLoader)?.pluginDescriptor
         if (pluginDescriptor == null) {
             LOG.error("Failed to find plugin descriptor")
             return null

--- a/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLspServerSupportProvider.kt
+++ b/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLspServerSupportProvider.kt
@@ -80,9 +80,9 @@ class PytestLspServerSupportProviderFallback : LspServerSupportProvider {
         private fun isLspModuleAvailable(): Boolean {
             return try {
                 val lspModuleId = PluginId.getId("com.intellij.modules.lsp")
-                // Use non-deprecated API: check if plugin exists and is not disabled
-                val plugin = PluginManagerCore.getPlugin(lspModuleId)
-                val isAvailable = plugin != null && !PluginManagerCore.isDisabled(lspModuleId)
+                // Use only non-internal PluginManagerCore APIs (getPlugin is now @Internal)
+                val isAvailable = PluginManagerCore.isPluginInstalled(lspModuleId) &&
+                    !PluginManagerCore.isDisabled(lspModuleId)
                 if (isAvailable) {
                     LOG.info("com.intellij.modules.lsp is available, fallback provider will not be registered")
                 }


### PR DESCRIPTION
The Marketplace verifier for 2026.2 EAP flags two usages of `PluginManagerCore.getPlugin(PluginId)`, which is now `@ApiStatus.Internal`. Both are replaced with public API:

- `PytestLanguageServerService` resolved this plugin's own path through `getPlugin`. It now reads the descriptor from its own classloader: `(javaClass.classLoader as? PluginAwareClassLoader)?.pluginDescriptor`. Both `PluginAwareClassLoader.getPluginDescriptor()` and `PluginDescriptor.getPluginPath()` are public.
- `PytestLspServerSupportProviderFallback` checked module availability with `getPlugin(id) != null`. It now uses `PluginManagerCore.isPluginInstalled(id)`, which together with the existing `isDisabled(id)` check keeps the same behavior. Both methods are public in current intellij-community master; only `getPlugin`/`findPlugin`/`plugins` are internal.

No `getPlugin` calls remain in the plugin sources.

Not compiled locally: the cached PyCharm 2023.2 DMG in the Gradle cache is corrupt and won't mount, so `./gradlew compileKotlin` fails before reaching these files. CI will build it.