### PR TITLE
feat: rename pytest.mark.parametrize parameters (#165)

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -22,4 +22,9 @@ allow_licenses:
   - Unicode-DFS-2016
   - BSL-1.0
 
+# rustpython-ast is published under MIT (see its Cargo.toml), but GitHub's
+# dependency graph reports its license as unknown, so exempt it explicitly.
+allow_dependencies_licenses:
+  - pkg:cargo/rustpython-ast
+
 comment_summary_in_pr: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "once_cell",
  "predicates",
  "rayon",
+ "rustpython-ast",
  "rustpython-parser",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tower-lsp-server = "0.23.0"
 tokio = { version = "1.52", features = ["full"] }
 serde_json = "1.0"
 rustpython-parser = "0.4.0"
+rustpython-ast = { version = "0.4.0", features = ["visitor"] }
 walkdir = "2.5"
 dashmap = "6.2"
 once_cell = "1.21"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ documentation, diagnostics, and more!
   - [Call Hierarchy](#-call-hierarchy)
   - [Code Completion](#-code-completion)
   - [Find References](#-find-references)
+  - [Rename](#-rename)
   - [Hover Documentation](#-hover-documentation)
   - [Document Symbols](#-document-symbols)
   - [Workspace Symbols](#-workspace-symbols)
@@ -109,6 +110,14 @@ Find all usages of a fixture across your entire test suite:
 - Shows references in all test files
 - Correctly handles fixture overriding and hierarchies
 - **LSP spec compliant**: Always includes the current position in results
+
+### ✏️ Rename
+Rename a `@pytest.mark.parametrize` parameter and update every occurrence at once:
+- Rewrites the name in the parametrize decorator string, the test signature, and the test body
+- Triggers from any of those three sites
+- Supports all argname forms: single name, comma-separated string, list, tuple, and `argnames=`
+- Works across stacked parametrize decorators
+- Indirect parameters (`indirect=True`) are left to your Python language server, since they map to fixtures
 
 ### 📚 Hover Documentation
 View fixture information on hover:

--- a/extensions/intellij-plugin/README.md
+++ b/extensions/intellij-plugin/README.md
@@ -17,6 +17,7 @@ A blazingly fast Language Server Protocol implementation for pytest fixtures, wr
 - **Call Hierarchy**: Explore fixture dependencies (incoming/outgoing calls)
 - **Code Completion**: Smart auto-completion for pytest fixtures with context-aware suggestions
 - **Find References**: Find all usages of a fixture
+- **Rename**: Rename a `@pytest.mark.parametrize` parameter and update the decorator string, signature, and body together
 - **Hover Documentation**: View fixture signatures and docstrings
 - **Document Symbols**: Navigate fixtures within a file using the outline view
 - **Workspace Symbols**: Search for fixtures across your entire workspace

--- a/extensions/vscode-extension/README.md
+++ b/extensions/vscode-extension/README.md
@@ -9,6 +9,7 @@ A blazingly fast Language Server Protocol implementation for pytest fixtures, wr
 - **Call Hierarchy**: Explore fixture dependencies (incoming/outgoing calls)
 - **Code Completion**: Smart auto-completion for pytest fixtures with context-aware suggestions
 - **Find References**: Find all usages of a fixture
+- **Rename**: Rename a `@pytest.mark.parametrize` parameter and update the decorator string, signature, and body together
 - **Hover Documentation**: View fixture signatures and docstrings
 - **Document Symbols**: Navigate fixtures within a file using the outline view
 - **Workspace Symbols**: Search for fixtures across your entire workspace

--- a/extensions/zed-extension/README.md
+++ b/extensions/zed-extension/README.md
@@ -9,6 +9,7 @@ This is a [Zed](https://zed.dev) extension that provides support for the [pytest
 - **Call Hierarchy**: Explore fixture dependencies (incoming/outgoing calls)
 - **Code Completion**: Smart auto-completion for pytest fixtures with context-aware suggestions
 - **Find References**: Find all usages of a fixture across your entire test suite
+- **Rename**: Rename a `@pytest.mark.parametrize` parameter and update the decorator string, signature, and body together
 - **Hover Documentation**: View fixture information including signature, location, and docstring
 - **Document Symbols**: Navigate fixtures within a file using the outline view
 - **Workspace Symbols**: Search for fixtures across your entire workspace

--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -132,8 +132,8 @@ pub fn is_parametrize_decorator(expr: &Expr) -> bool {
 /// concatenated string literals, so a rename never corrupts the file.
 fn is_plain_identifier(name: &str) -> bool {
     let mut chars = name.chars();
-    matches!(chars.next(), Some(c) if c == '_' || c.is_alphabetic())
-        && chars.all(|c| c == '_' || c.is_alphanumeric())
+    matches!(chars.next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 /// Splits the *source text* of a string literal into argnames, each paired with the precise

--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -127,24 +127,65 @@ pub fn is_parametrize_decorator(expr: &Expr) -> bool {
     is_pytest_mark_decorator(expr, "parametrize")
 }
 
-/// Splits a comma-separated argnames string value into individual names, each paired with a
-/// precise [`TextRange`] covering just the identifier (no quotes, no surrounding whitespace).
+/// Returns true if `name` is a plain Python identifier (the only thing a parametrize argname can
+/// legally be). Used to reject anything we couldn't cleanly locate in the source, e.g. implicitly
+/// concatenated string literals, so a rename never corrupts the file.
+fn is_plain_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c == '_' || c.is_alphabetic())
+        && chars.all(|c| c == '_' || c.is_alphanumeric())
+}
+
+/// Splits the *source text* of a string literal into argnames, each paired with the precise
+/// [`TextRange`] of its identifier token.
 ///
-/// `content_start` is the source offset of the first character of the string's content (i.e.
-/// immediately after the opening quote).
-fn split_argnames_with_ranges(
-    value: &str,
-    content_start: rustpython_parser::text_size::TextSize,
+/// Working from the source (rather than the parsed value) keeps the ranges correct regardless of
+/// quote style: `range_start` is the offset of the literal's opening prefix/quote, so the actual
+/// content offset is derived by skipping any string prefix (`r`, `b`, `u`, `f`) and the quote run
+/// (`'`, `"`, or their triple variants).
+fn split_argnames_from_source(
+    literal: &str,
+    range_start: rustpython_parser::text_size::TextSize,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
     use rustpython_parser::text_size::{TextRange, TextSize};
 
+    let bytes = literal.as_bytes();
+    let mut prefix = 0;
+    while prefix < bytes.len()
+        && matches!(
+            bytes[prefix],
+            b'r' | b'R' | b'b' | b'B' | b'u' | b'U' | b'f' | b'F'
+        )
+    {
+        prefix += 1;
+    }
+    let Some(&quote) = bytes.get(prefix) else {
+        return vec![];
+    };
+    if quote != b'"' && quote != b'\'' {
+        return vec![];
+    }
+    let quote_len =
+        if bytes.len() >= prefix + 3 && bytes[prefix + 1] == quote && bytes[prefix + 2] == quote {
+            3
+        } else {
+            1
+        };
+
+    let content_offset = prefix + quote_len;
+    let content_end = literal.len().saturating_sub(quote_len);
+    if content_offset > content_end {
+        return vec![];
+    }
+    let inner = &literal[content_offset..content_end];
+
     let mut result = Vec::new();
-    let mut offset = 0usize; // byte offset within `value`
-    for segment in value.split(',') {
+    let mut offset = content_offset;
+    for segment in inner.split(',') {
         let leading_ws = segment.len() - segment.trim_start().len();
         let trimmed = segment.trim();
-        if !trimmed.is_empty() {
-            let start = content_start + TextSize::from((offset + leading_ws) as u32);
+        if is_plain_identifier(trimmed) {
+            let start = range_start + TextSize::from((offset + leading_ws) as u32);
             let end = start + TextSize::from(trimmed.len() as u32);
             result.push((trimmed.to_string(), TextRange::new(start, end)));
         }
@@ -158,11 +199,12 @@ fn split_argnames_with_ranges(
 ///
 /// Handles every argnames form pytest accepts: a single name, a comma-separated string
 /// (`"a,b"` / `"a, b"`), a list or tuple of strings, and `argnames=` passed as a keyword.
+/// `content` is the full source of the file the decorator came from, used to read each string
+/// literal's exact text.
 pub fn extract_parametrize_argnames(
     expr: &Expr,
+    content: &str,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
-    use rustpython_parser::text_size::TextSize;
-
     let Expr::Call(call) = expr else {
         return vec![];
     };
@@ -182,41 +224,88 @@ pub fn extract_parametrize_argnames(
     };
 
     match argnames {
-        Expr::Constant(c) => {
-            if let rustpython_parser::ast::Constant::Str(s) = &c.value {
-                // Skip the opening quote to reach the string content.
-                let content_start = c.range.start() + TextSize::from(1);
-                return split_argnames_with_ranges(s, content_start);
-            }
-            vec![]
-        }
+        Expr::Constant(_) => parametrize_name_element_ranges(argnames, content),
         Expr::List(list) => list
             .elts
             .iter()
-            .flat_map(parametrize_name_element_ranges)
+            .flat_map(|elt| parametrize_name_element_ranges(elt, content))
             .collect(),
         Expr::Tuple(tuple) => tuple
             .elts
             .iter()
-            .flat_map(parametrize_name_element_ranges)
+            .flat_map(|elt| parametrize_name_element_ranges(elt, content))
             .collect(),
         _ => vec![],
     }
 }
 
-/// Extracts name/range pairs from a single element of a list/tuple argnames spec.
+/// Extracts name/range pairs from a single string-literal element of an argnames spec.
 fn parametrize_name_element_ranges(
     elt: &Expr,
+    content: &str,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
-    use rustpython_parser::text_size::TextSize;
-
-    if let Expr::Constant(c) = elt {
-        if let rustpython_parser::ast::Constant::Str(s) = &c.value {
-            let content_start = c.range.start() + TextSize::from(1);
-            return split_argnames_with_ranges(s, content_start);
-        }
+    let Expr::Constant(c) = elt else {
+        return vec![];
+    };
+    if !matches!(c.value, rustpython_parser::ast::Constant::Str(_)) {
+        return vec![];
     }
-    vec![]
+    let start = c.range.start().to_usize();
+    let end = c.range.end().to_usize();
+    let Some(literal) = content.get(start..end) else {
+        return vec![];
+    };
+    split_argnames_from_source(literal, c.range.start())
+}
+
+/// Returns the subset of `argnames` that a `@pytest.mark.parametrize(...)` decorator marks as
+/// indirect (`indirect=True` marks all of them; `indirect=[names]` marks the listed ones).
+///
+/// `indirect` may be passed by keyword or as the third positional argument.
+pub fn extract_parametrize_indirect_names(
+    expr: &Expr,
+    argnames: &[String],
+) -> std::collections::HashSet<String> {
+    use std::collections::HashSet;
+
+    let Expr::Call(call) = expr else {
+        return HashSet::new();
+    };
+    if !is_parametrize_decorator(&call.func) {
+        return HashSet::new();
+    }
+
+    let indirect = call
+        .keywords
+        .iter()
+        .find(|kw| kw.arg.as_ref().is_some_and(|a| a.as_str() == "indirect"))
+        .map(|kw| &kw.value)
+        .or_else(|| call.args.get(2));
+
+    let Some(indirect) = indirect else {
+        return HashSet::new();
+    };
+
+    match indirect {
+        Expr::Constant(c) if matches!(c.value, rustpython_parser::ast::Constant::Bool(true)) => {
+            argnames.iter().cloned().collect()
+        }
+        Expr::List(list) => collect_string_constants(&list.elts),
+        Expr::Tuple(tuple) => collect_string_constants(&tuple.elts),
+        _ => HashSet::new(),
+    }
+}
+
+fn collect_string_constants(elts: &[Expr]) -> std::collections::HashSet<String> {
+    elts.iter()
+        .filter_map(|elt| match elt {
+            Expr::Constant(c) => match &c.value {
+                rustpython_parser::ast::Constant::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
 }
 
 /// Extracts fixture names from @pytest.mark.parametrize when indirect=True.

--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -127,6 +127,98 @@ pub fn is_parametrize_decorator(expr: &Expr) -> bool {
     is_pytest_mark_decorator(expr, "parametrize")
 }
 
+/// Splits a comma-separated argnames string value into individual names, each paired with a
+/// precise [`TextRange`] covering just the identifier (no quotes, no surrounding whitespace).
+///
+/// `content_start` is the source offset of the first character of the string's content (i.e.
+/// immediately after the opening quote).
+fn split_argnames_with_ranges(
+    value: &str,
+    content_start: rustpython_parser::text_size::TextSize,
+) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
+    use rustpython_parser::text_size::{TextRange, TextSize};
+
+    let mut result = Vec::new();
+    let mut offset = 0usize; // byte offset within `value`
+    for segment in value.split(',') {
+        let leading_ws = segment.len() - segment.trim_start().len();
+        let trimmed = segment.trim();
+        if !trimmed.is_empty() {
+            let start = content_start + TextSize::from((offset + leading_ws) as u32);
+            let end = start + TextSize::from(trimmed.len() as u32);
+            result.push((trimmed.to_string(), TextRange::new(start, end)));
+        }
+        offset += segment.len() + 1; // +1 for the comma separator
+    }
+    result
+}
+
+/// Extracts the declared parameter names from a `@pytest.mark.parametrize(...)` decorator, each
+/// paired with the precise [`TextRange`] of its name token.
+///
+/// Handles every argnames form pytest accepts: a single name, a comma-separated string
+/// (`"a,b"` / `"a, b"`), a list or tuple of strings, and `argnames=` passed as a keyword.
+pub fn extract_parametrize_argnames(
+    expr: &Expr,
+) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
+    use rustpython_parser::text_size::TextSize;
+
+    let Expr::Call(call) = expr else {
+        return vec![];
+    };
+    if !is_parametrize_decorator(&call.func) {
+        return vec![];
+    }
+
+    let argnames = call.args.first().or_else(|| {
+        call.keywords
+            .iter()
+            .find(|kw| kw.arg.as_ref().is_some_and(|a| a.as_str() == "argnames"))
+            .map(|kw| &kw.value)
+    });
+
+    let Some(argnames) = argnames else {
+        return vec![];
+    };
+
+    match argnames {
+        Expr::Constant(c) => {
+            if let rustpython_parser::ast::Constant::Str(s) = &c.value {
+                // Skip the opening quote to reach the string content.
+                let content_start = c.range.start() + TextSize::from(1);
+                return split_argnames_with_ranges(s, content_start);
+            }
+            vec![]
+        }
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .flat_map(parametrize_name_element_ranges)
+            .collect(),
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .flat_map(parametrize_name_element_ranges)
+            .collect(),
+        _ => vec![],
+    }
+}
+
+/// Extracts name/range pairs from a single element of a list/tuple argnames spec.
+fn parametrize_name_element_ranges(
+    elt: &Expr,
+) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
+    use rustpython_parser::text_size::TextSize;
+
+    if let Expr::Constant(c) = elt {
+        if let rustpython_parser::ast::Constant::Str(s) = &c.value {
+            let content_start = c.range.start() + TextSize::from(1);
+            return split_argnames_with_ranges(s, content_start);
+        }
+    }
+    vec![]
+}
+
 /// Extracts fixture names from @pytest.mark.parametrize when indirect=True.
 pub fn extract_parametrize_indirect_fixtures(
     expr: &Expr,

--- a/src/providers/language_server.rs
+++ b/src/providers/language_server.rs
@@ -151,6 +151,12 @@ impl LanguageServer for Backend {
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
                 call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
+                rename_provider: Some(OneOf::Right(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                })),
                 ..Default::default()
             },
         })
@@ -327,6 +333,17 @@ impl LanguageServer for Backend {
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         self.handle_references(params).await
+    }
+
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        self.handle_prepare_rename(params).await
+    }
+
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        self.handle_rename(params).await
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod implementation;
 pub mod inlay_hint;
 mod language_server;
 pub mod references;
+pub mod rename;
 pub mod workspace_symbol;
 
 use crate::config::Config;

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -345,10 +345,7 @@ impl Backend {
             .find(|(_, ranges)| ranges.iter().any(|r| range_contains(r, cursor_offset)))
             .map(|(name, _)| name.clone())
             .or_else(|| {
-                let line_content = content.lines().nth(position.line as usize)?;
-                let word = self
-                    .fixture_db
-                    .extract_word_at_position(line_content, position.character as usize)?;
+                let word = identifier_at(content, cursor_offset)?;
                 (name_to_decorator_ranges.contains_key(&word)
                     && signature_params.contains(word.as_str()))
                 .then_some(word)
@@ -427,6 +424,32 @@ impl Backend {
 
 fn range_contains(range: &TextRange, offset: usize) -> bool {
     range.start().to_usize() <= offset && offset <= range.end().to_usize()
+}
+
+/// Returns the ASCII identifier spanning `offset` in `content`, treating `offset` inclusively so
+/// a caret resting just past the last character (a common rename position) still resolves.
+///
+/// Works in byte offsets to stay consistent with the rest of this provider; identifiers are ASCII
+/// so this never splits a multi-byte character.
+fn identifier_at(content: &str, offset: usize) -> Option<String> {
+    let bytes = content.as_bytes();
+    if offset > bytes.len() {
+        return None;
+    }
+    let is_word = |b: u8| b == b'_' || b.is_ascii_alphanumeric();
+
+    let mut start = offset;
+    while start > 0 && is_word(bytes[start - 1]) {
+        start -= 1;
+    }
+    let mut end = offset;
+    while end < bytes.len() && is_word(bytes[end]) {
+        end += 1;
+    }
+    if start == end {
+        return None;
+    }
+    Some(content[start..end].to_string())
 }
 
 /// Recursively collect every function definition, descending into classes and nested functions.

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -306,12 +306,19 @@ impl Backend {
         let line_index = FixtureDatabase::build_line_index(content);
         let cursor_offset = *line_index.get(position.line as usize)? + position.character as usize;
 
-        // Innermost function whose decorators or body contain the cursor.
+        // Innermost *parametrized* function whose decorators or body contain the cursor. Filtering
+        // to parametrized functions means a cursor inside a nested closure that references the
+        // parameter still resolves to the enclosing parametrized test rather than the closure.
         let mut functions = Vec::new();
         collect_functions(&module.body, &mut functions);
         let func = functions
             .into_iter()
             .filter(|f| f.contains(cursor_offset))
+            .filter(|f| {
+                f.decorators
+                    .iter()
+                    .any(|d| !decorators::extract_parametrize_argnames(d, content).is_empty())
+            })
             .min_by_key(FuncCtx::span)?;
 
         // Parametrize names declared across all decorators, excluding indirect ones (those route

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -74,8 +74,9 @@ impl FuncCtx<'_> {
 /// are not collected. Parts evaluated in the enclosing scope (decorators, parameter defaults and
 /// annotations, the first comprehension iterable) are still visited.
 ///
-/// Limitation: a nested function that rebinds the name by assignment (rather than by parameter) is
-/// not detected; that case over-collects. It does not occur in practice in test bodies.
+/// Limitation: a nested function that rebinds the name by assignment, `global`, or `nonlocal`
+/// (rather than by parameter) is not detected; that case over-collects. It does not occur in
+/// practice in test bodies.
 struct NameUsageCollector {
     target: String,
     ranges: Vec<TextRange>,

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -1,0 +1,325 @@
+//! Rename provider for `@pytest.mark.parametrize` parameters.
+//!
+//! Renaming a parametrized parameter rewrites, in one edit, the name token inside the
+//! `@pytest.mark.parametrize(...)` decorator string, the matching function-signature parameter,
+//! and every usage of that parameter in the function body.  The rename can be triggered from any
+//! of those three sites.
+//!
+//! Only parametrize parameters are handled; for any other symbol the request returns `None` so a
+//! general Python language server can answer it.
+
+use super::Backend;
+use crate::fixtures::{decorators, FixtureDatabase};
+use rustpython_parser::ast::{Arguments, Expr, ExprName, Ranged, Stmt, Visitor};
+use rustpython_parser::text_size::TextRange;
+use rustpython_parser::{parse, Mode};
+use std::collections::{HashMap, HashSet};
+use tower_lsp_server::jsonrpc::{Error, Result};
+use tower_lsp_server::ls_types::*;
+use tracing::info;
+
+const PYTHON_KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+    "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+    "with", "yield",
+];
+
+/// All occurrences of a parametrize parameter within one test function that must change together.
+struct RenameTarget {
+    /// LSP range of the token under the cursor (for the prepareRename response).
+    cursor_token: Range,
+    /// Every editable occurrence: decorator name token(s), signature parameter, body usages.
+    edits: Vec<Range>,
+}
+
+/// A function definition with the parts needed for parametrize rename, borrowed from the AST.
+struct FuncCtx<'a> {
+    decorators: &'a [Expr],
+    args: &'a Arguments,
+    body: &'a [Stmt],
+    range: TextRange,
+}
+
+impl FuncCtx<'_> {
+    /// Source span covering the decorators and the `def` body, used to locate the cursor.
+    /// (`FunctionDef.range` starts at `def`, so decorators must be folded in explicitly.)
+    fn bounds(&self) -> (usize, usize) {
+        let mut start = self.range.start().to_usize();
+        for dec in self.decorators {
+            start = start.min(dec.range().start().to_usize());
+        }
+        (start, self.range.end().to_usize())
+    }
+
+    fn contains(&self, offset: usize) -> bool {
+        let (start, end) = self.bounds();
+        start <= offset && offset <= end
+    }
+
+    fn span(&self) -> usize {
+        let (start, end) = self.bounds();
+        end - start
+    }
+}
+
+/// Collects the ranges of every `Name` expression matching a target identifier, recursing through
+/// the whole subtree via the generated `Visitor` default traversal.
+struct NameUsageCollector {
+    target: String,
+    ranges: Vec<TextRange>,
+}
+
+impl Visitor for NameUsageCollector {
+    fn visit_expr_name(&mut self, node: ExprName) {
+        if node.id.as_str() == self.target {
+            self.ranges.push(node.range);
+        }
+    }
+}
+
+impl Backend {
+    /// Handle a `textDocument/prepareRename` request.
+    pub async fn handle_prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        let uri = params.text_document.uri;
+        let position = params.position;
+
+        let Some(file_path) = self.uri_to_path(&uri) else {
+            return Ok(None);
+        };
+        let Some(content) = self.fixture_db.get_file_content(&file_path) else {
+            return Ok(None);
+        };
+
+        Ok(self
+            .parametrize_rename_target(&content, position)
+            .map(|target| PrepareRenameResponse::Range(target.cursor_token)))
+    }
+
+    /// Handle a `textDocument/rename` request.
+    pub async fn handle_rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let new_name = params.new_name;
+
+        let Some(file_path) = self.uri_to_path(&uri) else {
+            return Ok(None);
+        };
+        let Some(content) = self.fixture_db.get_file_content(&file_path) else {
+            return Ok(None);
+        };
+
+        let Some(target) = self.parametrize_rename_target(&content, position) else {
+            return Ok(None);
+        };
+
+        if !is_valid_python_identifier(&new_name) {
+            return Err(Error::invalid_params(format!(
+                "'{new_name}' is not a valid Python identifier"
+            )));
+        }
+
+        info!(
+            "rename: {} occurrence(s) of parametrize param -> '{}'",
+            target.edits.len(),
+            new_name
+        );
+
+        let edits: Vec<TextEdit> = target
+            .edits
+            .into_iter()
+            .map(|range| TextEdit {
+                range,
+                new_text: new_name.clone(),
+            })
+            .collect();
+
+        let mut changes = HashMap::new();
+        changes.insert(uri, edits);
+
+        Ok(Some(WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        }))
+    }
+
+    /// Resolve the parametrize parameter at `position` and gather all of its occurrences.
+    fn parametrize_rename_target(&self, content: &str, position: Position) -> Option<RenameTarget> {
+        let rustpython_parser::ast::Mod::Module(module) = parse(content, Mode::Module, "").ok()?
+        else {
+            return None;
+        };
+
+        let line_index = FixtureDatabase::build_line_index(content);
+        let cursor_offset = *line_index.get(position.line as usize)? + position.character as usize;
+
+        // Innermost function whose decorators or body contain the cursor.
+        let mut functions = Vec::new();
+        collect_functions(&module.body, &mut functions);
+        let func = functions
+            .into_iter()
+            .filter(|f| f.contains(cursor_offset))
+            .min_by_key(FuncCtx::span)?;
+
+        // Parametrize names declared across all decorators, excluding indirect ones (those route
+        // to a fixture, so a local-only rename would silently break the test).
+        let mut name_to_decorator_ranges: HashMap<String, Vec<TextRange>> = HashMap::new();
+        let mut indirect: HashSet<String> = HashSet::new();
+        for dec in func.decorators {
+            for (name, _) in decorators::extract_parametrize_indirect_fixtures(dec) {
+                indirect.insert(name);
+            }
+        }
+        for dec in func.decorators {
+            for (name, range) in decorators::extract_parametrize_argnames(dec) {
+                if indirect.contains(&name) {
+                    continue;
+                }
+                name_to_decorator_ranges
+                    .entry(name)
+                    .or_default()
+                    .push(range);
+            }
+        }
+        if name_to_decorator_ranges.is_empty() {
+            return None;
+        }
+
+        // Signature parameter names, used to confirm the cursor sits on a real parameter.
+        let signature_params: HashSet<&str> = FixtureDatabase::all_args(func.args)
+            .map(|arg| arg.def.arg.as_str())
+            .collect();
+
+        // Determine the target name from whichever site the cursor is on.
+        let target_name = name_to_decorator_ranges
+            .iter()
+            .find(|(_, ranges)| ranges.iter().any(|r| range_contains(r, cursor_offset)))
+            .map(|(name, _)| name.clone())
+            .or_else(|| {
+                let line_content = content.lines().nth(position.line as usize)?;
+                let word = self
+                    .fixture_db
+                    .extract_word_at_position(line_content, position.character as usize)?;
+                (name_to_decorator_ranges.contains_key(&word)
+                    && signature_params.contains(word.as_str()))
+                .then_some(word)
+            })?;
+
+        // Gather every occurrence to edit.
+        let mut occurrences: Vec<TextRange> = Vec::new();
+        occurrences.extend(
+            name_to_decorator_ranges
+                .remove(&target_name)
+                .into_iter()
+                .flatten(),
+        );
+
+        if let Some(arg) =
+            FixtureDatabase::all_args(func.args).find(|arg| arg.def.arg.as_str() == target_name)
+        {
+            let start = arg.def.range.start();
+            occurrences.push(TextRange::new(
+                start,
+                start + rustpython_parser::text_size::TextSize::from(target_name.len() as u32),
+            ));
+        }
+
+        let mut collector = NameUsageCollector {
+            target: target_name.clone(),
+            ranges: Vec::new(),
+        };
+        for stmt in func.body {
+            collector.visit_stmt(stmt.clone());
+        }
+        occurrences.extend(collector.ranges);
+
+        occurrences.sort_by_key(|r| (r.start().to_usize(), r.end().to_usize()));
+        occurrences.dedup();
+
+        let cursor_tr = occurrences
+            .iter()
+            .find(|r| range_contains(r, cursor_offset))
+            .copied()
+            .unwrap_or(occurrences[0]);
+
+        let to_lsp = |tr: &TextRange| self.text_range_to_lsp(tr, &line_index);
+        Some(RenameTarget {
+            cursor_token: to_lsp(&cursor_tr),
+            edits: occurrences.iter().map(to_lsp).collect(),
+        })
+    }
+
+    /// Convert a source [`TextRange`] into an LSP [`Range`] using the file's line index.
+    fn text_range_to_lsp(&self, tr: &TextRange, line_index: &[usize]) -> Range {
+        let start_offset = tr.start().to_usize();
+        let end_offset = tr.end().to_usize();
+        let start_line = self
+            .fixture_db
+            .get_line_from_offset(start_offset, line_index);
+        let end_line = self.fixture_db.get_line_from_offset(end_offset, line_index);
+        Range {
+            start: Position {
+                line: (start_line - 1) as u32,
+                character: self
+                    .fixture_db
+                    .get_char_position_from_offset(start_offset, line_index)
+                    as u32,
+            },
+            end: Position {
+                line: (end_line - 1) as u32,
+                character: self
+                    .fixture_db
+                    .get_char_position_from_offset(end_offset, line_index)
+                    as u32,
+            },
+        }
+    }
+}
+
+fn range_contains(range: &TextRange, offset: usize) -> bool {
+    range.start().to_usize() <= offset && offset <= range.end().to_usize()
+}
+
+/// Recursively collect every function definition, descending into classes and nested functions.
+fn collect_functions<'a>(stmts: &'a [Stmt], out: &mut Vec<FuncCtx<'a>>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::FunctionDef(f) => {
+                out.push(FuncCtx {
+                    decorators: &f.decorator_list,
+                    args: &f.args,
+                    body: &f.body,
+                    range: f.range,
+                });
+                collect_functions(&f.body, out);
+            }
+            Stmt::AsyncFunctionDef(f) => {
+                out.push(FuncCtx {
+                    decorators: &f.decorator_list,
+                    args: &f.args,
+                    body: &f.body,
+                    range: f.range,
+                });
+                collect_functions(&f.body, out);
+            }
+            Stmt::ClassDef(c) => collect_functions(&c.body, out),
+            _ => {}
+        }
+    }
+}
+
+fn is_valid_python_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    if !chars.all(|c| c == '_' || c.is_ascii_alphanumeric()) {
+        return false;
+    }
+    !PYTHON_KEYWORDS.contains(&name)
+}

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -10,7 +10,10 @@
 
 use super::Backend;
 use crate::fixtures::{decorators, FixtureDatabase};
-use rustpython_parser::ast::{Arguments, Expr, ExprName, Ranged, Stmt, Visitor};
+use rustpython_parser::ast::{
+    Arguments, Expr, ExprDictComp, ExprGeneratorExp, ExprLambda, ExprListComp, ExprName,
+    ExprSetComp, Ranged, Stmt, StmtAsyncFunctionDef, StmtFunctionDef, Visitor,
+};
 use rustpython_parser::text_size::TextRange;
 use rustpython_parser::{parse, Mode};
 use std::collections::{HashMap, HashSet};
@@ -63,11 +66,75 @@ impl FuncCtx<'_> {
     }
 }
 
-/// Collects the ranges of every `Name` expression matching a target identifier, recursing through
-/// the whole subtree via the generated `Visitor` default traversal.
+/// Collects the ranges of every `Name` expression that refers to a target parameter, walking the
+/// function body via the generated `Visitor`.
+///
+/// It is scope-aware: a nested function/lambda whose parameters shadow the target, and a
+/// comprehension whose loop target shadows it, bind a *different* variable, so their inner bodies
+/// are not collected. Parts evaluated in the enclosing scope (decorators, parameter defaults and
+/// annotations, the first comprehension iterable) are still visited.
+///
+/// Limitation: a nested function that rebinds the name by assignment (rather than by parameter) is
+/// not detected; that case over-collects. It does not occur in practice in test bodies.
 struct NameUsageCollector {
     target: String,
     ranges: Vec<TextRange>,
+}
+
+impl NameUsageCollector {
+    /// Visit parameter defaults and annotations, which are evaluated in the enclosing scope.
+    fn visit_arg_context(&mut self, args: &Arguments) {
+        for arg in args
+            .posonlyargs
+            .iter()
+            .chain(&args.args)
+            .chain(&args.kwonlyargs)
+        {
+            if let Some(default) = &arg.default {
+                self.visit_expr((**default).clone());
+            }
+            if let Some(annotation) = &arg.def.annotation {
+                self.visit_expr((**annotation).clone());
+            }
+        }
+        if let Some(va) = &args.vararg {
+            if let Some(annotation) = &va.annotation {
+                self.visit_expr((**annotation).clone());
+            }
+        }
+        if let Some(kw) = &args.kwarg {
+            if let Some(annotation) = &kw.annotation {
+                self.visit_expr((**annotation).clone());
+            }
+        }
+    }
+
+    fn visit_comprehension(
+        &mut self,
+        elements: Vec<Expr>,
+        generators: Vec<rustpython_parser::ast::Comprehension>,
+    ) {
+        let shadows = generators
+            .iter()
+            .any(|g| expr_binds_name(&g.target, &self.target));
+
+        for (i, generator) in generators.into_iter().enumerate() {
+            // The first generator's iterable is evaluated in the enclosing scope.
+            if i == 0 || !shadows {
+                self.visit_expr(generator.iter);
+            }
+            if !shadows {
+                for cond in generator.ifs {
+                    self.visit_expr(cond);
+                }
+            }
+        }
+        if !shadows {
+            for element in elements {
+                self.visit_expr(element);
+            }
+        }
+    }
 }
 
 impl Visitor for NameUsageCollector {
@@ -75,6 +142,87 @@ impl Visitor for NameUsageCollector {
         if node.id.as_str() == self.target {
             self.ranges.push(node.range);
         }
+    }
+
+    fn visit_stmt_function_def(&mut self, node: StmtFunctionDef) {
+        for decorator in node.decorator_list {
+            self.visit_expr(decorator);
+        }
+        self.visit_arg_context(&node.args);
+        if let Some(returns) = node.returns {
+            self.visit_expr(*returns);
+        }
+        if !args_bind(&node.args, &self.target) {
+            for stmt in node.body {
+                self.visit_stmt(stmt);
+            }
+        }
+    }
+
+    fn visit_stmt_async_function_def(&mut self, node: StmtAsyncFunctionDef) {
+        for decorator in node.decorator_list {
+            self.visit_expr(decorator);
+        }
+        self.visit_arg_context(&node.args);
+        if let Some(returns) = node.returns {
+            self.visit_expr(*returns);
+        }
+        if !args_bind(&node.args, &self.target) {
+            for stmt in node.body {
+                self.visit_stmt(stmt);
+            }
+        }
+    }
+
+    fn visit_expr_lambda(&mut self, node: ExprLambda) {
+        self.visit_arg_context(&node.args);
+        if !args_bind(&node.args, &self.target) {
+            self.visit_expr(*node.body);
+        }
+    }
+
+    fn visit_expr_list_comp(&mut self, node: ExprListComp) {
+        self.visit_comprehension(vec![*node.elt], node.generators);
+    }
+
+    fn visit_expr_set_comp(&mut self, node: ExprSetComp) {
+        self.visit_comprehension(vec![*node.elt], node.generators);
+    }
+
+    fn visit_expr_generator_exp(&mut self, node: ExprGeneratorExp) {
+        self.visit_comprehension(vec![*node.elt], node.generators);
+    }
+
+    fn visit_expr_dict_comp(&mut self, node: ExprDictComp) {
+        self.visit_comprehension(vec![*node.key, *node.value], node.generators);
+    }
+}
+
+/// Whether any parameter of `args` is named `target`.
+fn args_bind(args: &Arguments, target: &str) -> bool {
+    args.posonlyargs
+        .iter()
+        .chain(&args.args)
+        .chain(&args.kwonlyargs)
+        .any(|arg| arg.def.arg.as_str() == target)
+        || args
+            .vararg
+            .as_ref()
+            .is_some_and(|a| a.arg.as_str() == target)
+        || args
+            .kwarg
+            .as_ref()
+            .is_some_and(|a| a.arg.as_str() == target)
+}
+
+/// Whether an assignment/comprehension target binds `name` (handles tuple/list/star unpacking).
+fn expr_binds_name(target: &Expr, name: &str) -> bool {
+    match target {
+        Expr::Name(n) => n.id.as_str() == name,
+        Expr::Tuple(t) => t.elts.iter().any(|e| expr_binds_name(e, name)),
+        Expr::List(l) => l.elts.iter().any(|e| expr_binds_name(e, name)),
+        Expr::Starred(s) => expr_binds_name(&s.value, name),
+        _ => false,
     }
 }
 
@@ -168,14 +316,11 @@ impl Backend {
         // Parametrize names declared across all decorators, excluding indirect ones (those route
         // to a fixture, so a local-only rename would silently break the test).
         let mut name_to_decorator_ranges: HashMap<String, Vec<TextRange>> = HashMap::new();
-        let mut indirect: HashSet<String> = HashSet::new();
         for dec in func.decorators {
-            for (name, _) in decorators::extract_parametrize_indirect_fixtures(dec) {
-                indirect.insert(name);
-            }
-        }
-        for dec in func.decorators {
-            for (name, range) in decorators::extract_parametrize_argnames(dec) {
+            let argnames = decorators::extract_parametrize_argnames(dec, content);
+            let names: Vec<String> = argnames.iter().map(|(name, _)| name.clone()).collect();
+            let indirect = decorators::extract_parametrize_indirect_names(dec, &names);
+            for (name, range) in argnames {
                 if indirect.contains(&name) {
                     continue;
                 }

--- a/tests/test_decorators.rs
+++ b/tests/test_decorators.rs
@@ -235,3 +235,122 @@ fn test_extract_parametrize_indirect() {
         }
     }
 }
+
+/// Parse a single decorated function and return `(name, source_slice)` pairs from
+/// `extract_parametrize_argnames`, where `source_slice` is the exact substring the returned
+/// range points at — so tests can confirm ranges land on the identifier, not quotes/whitespace.
+fn argnames_with_slices(code: &str) -> Vec<(String, String)> {
+    let parsed = parse(code, Mode::Module, "").unwrap();
+    let rustpython_parser::ast::Mod::Module(module) = parsed else {
+        panic!("expected module");
+    };
+    let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] else {
+        panic!("expected function def");
+    };
+    func_def
+        .decorator_list
+        .iter()
+        .flat_map(decorators::extract_parametrize_argnames)
+        .map(|(name, range)| {
+            let slice = code[range.start().to_usize()..range.end().to_usize()].to_string();
+            (name, slice)
+        })
+        .collect()
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_single() {
+    let got = argnames_with_slices("@pytest.mark.parametrize('x', [1])\ndef test_x(x): pass");
+    assert_eq!(got, vec![("x".to_string(), "x".to_string())]);
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_comma_no_space() {
+    let got =
+        argnames_with_slices("@pytest.mark.parametrize('a,b', [(1, 2)])\ndef test_x(a, b): pass");
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_comma_with_spaces() {
+    // The ranges must skip the surrounding whitespace and land on the identifiers.
+    let got = argnames_with_slices(
+        "@pytest.mark.parametrize('a,  b ', [(1, 2)])\ndef test_x(a, b): pass",
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_list() {
+    let got = argnames_with_slices(
+        "@pytest.mark.parametrize(['a', 'b'], [(1, 2)])\ndef test_x(a, b): pass",
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_tuple() {
+    let got = argnames_with_slices(
+        "@pytest.mark.parametrize(('a', 'b'), [(1, 2)])\ndef test_x(a, b): pass",
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_keyword() {
+    let got = argnames_with_slices(
+        "@pytest.mark.parametrize(argnames='x', argvalues=[1])\ndef test_x(x): pass",
+    );
+    assert_eq!(got, vec![("x".to_string(), "x".to_string())]);
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_stacked() {
+    let code = "@pytest.mark.parametrize('a', [1])\n@pytest.mark.parametrize('b', [2])\ndef test_x(a, b): pass";
+    let got = argnames_with_slices(code);
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_not_parametrize() {
+    let got = argnames_with_slices("@pytest.mark.usefixtures('x')\ndef test_x(): pass");
+    assert!(got.is_empty());
+}

--- a/tests/test_decorators.rs
+++ b/tests/test_decorators.rs
@@ -430,3 +430,77 @@ fn test_indirect_names_partial_list() {
     assert!(indirect.contains("a"));
     assert!(!indirect.contains("b"));
 }
+
+/// Returns the indirect-name set for the first decorator of a single decorated function.
+fn indirect_names(code: &str) -> std::collections::HashSet<String> {
+    let parsed = parse(code, Mode::Module, "").unwrap();
+    let rustpython_parser::ast::Mod::Module(module) = parsed else {
+        panic!("expected module");
+    };
+    let dec = match &module.body[0] {
+        rustpython_parser::ast::Stmt::FunctionDef(f) => &f.decorator_list[0],
+        rustpython_parser::ast::Stmt::AsyncFunctionDef(f) => &f.decorator_list[0],
+        _ => panic!("expected function def"),
+    };
+    let names: Vec<String> = decorators::extract_parametrize_argnames(dec, code)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    decorators::extract_parametrize_indirect_names(dec, &names)
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_tuple_form() {
+    let names = indirect_names(
+        "@pytest.mark.parametrize('a,b', [(1, 2)], indirect=('a', 'b'))\ndef test_x(a, b): pass",
+    );
+    assert!(names.contains("a"));
+    assert!(names.contains("b"));
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_positional() {
+    // indirect passed as the third positional argument.
+    let names = indirect_names("@pytest.mark.parametrize('a', [1], True)\ndef test_x(a): pass");
+    assert!(names.contains("a"));
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_absent_or_false() {
+    assert!(indirect_names("@pytest.mark.parametrize('a', [1])\ndef test_x(a): pass").is_empty());
+    assert!(indirect_names(
+        "@pytest.mark.parametrize('a', [1], indirect=False)\ndef test_x(a): pass"
+    )
+    .is_empty());
+}
+
+#[test]
+#[timeout(30000)]
+fn test_argnames_non_string_forms_ignored() {
+    // A non-string/list/tuple argnames expression (e.g. a variable) yields nothing.
+    assert!(
+        argnames_with_slices("@pytest.mark.parametrize(NAMES, [1])\ndef test_x(a): pass")
+            .is_empty()
+    );
+    // List elements that are not string literals are skipped, whether they are non-constant
+    // expressions or non-string constants.
+    let got =
+        argnames_with_slices("@pytest.mark.parametrize([NAME, 'b'], [1])\ndef test_x(a, b): pass");
+    assert_eq!(got, vec![("b".to_string(), "b".to_string())]);
+    let got =
+        argnames_with_slices("@pytest.mark.parametrize([1, 'b'], [1])\ndef test_x(a, b): pass");
+    assert_eq!(got, vec![("b".to_string(), "b".to_string())]);
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_ignores_non_string_list_elements() {
+    // Non-string entries in an indirect list are ignored.
+    let names = indirect_names(
+        "@pytest.mark.parametrize('a,b', [(1, 2)], indirect=[1, other])\ndef test_x(a, b): pass",
+    );
+    assert!(names.is_empty());
+}

--- a/tests/test_decorators.rs
+++ b/tests/test_decorators.rs
@@ -250,7 +250,7 @@ fn argnames_with_slices(code: &str) -> Vec<(String, String)> {
     func_def
         .decorator_list
         .iter()
-        .flat_map(decorators::extract_parametrize_argnames)
+        .flat_map(|dec| decorators::extract_parametrize_argnames(dec, code))
         .map(|(name, range)| {
             let slice = code[range.start().to_usize()..range.end().to_usize()].to_string();
             (name, slice)
@@ -353,4 +353,80 @@ fn test_extract_parametrize_argnames_stacked() {
 fn test_extract_parametrize_argnames_not_parametrize() {
     let got = argnames_with_slices("@pytest.mark.usefixtures('x')\ndef test_x(): pass");
     assert!(got.is_empty());
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_triple_quoted() {
+    // The range must skip all three opening quotes and land on the identifier.
+    let got = argnames_with_slices(
+        "@pytest.mark.parametrize('''a, b''', [(1, 2)])\ndef test_x(a, b): pass",
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string())
+        ]
+    );
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_raw_string_prefix() {
+    // The `r` prefix must be skipped along with the quote.
+    let got =
+        argnames_with_slices("@pytest.mark.parametrize(r\"foo\", [1])\ndef test_x(foo): pass");
+    assert_eq!(got, vec![("foo".to_string(), "foo".to_string())]);
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_parametrize_argnames_rejects_non_identifier() {
+    // Implicitly concatenated literals can't be cleanly located, so nothing is returned rather
+    // than a corrupting range.
+    let got = argnames_with_slices("@pytest.mark.parametrize('a' 'b', [1])\ndef test_x(ab): pass");
+    assert!(got.is_empty());
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_keyword_argnames() {
+    let code = "@pytest.mark.parametrize(argnames='a,b', argvalues=[(1, 2)], indirect=True)\ndef test_x(a, b): pass";
+    let parsed = parse(code, Mode::Module, "").unwrap();
+    let rustpython_parser::ast::Mod::Module(module) = parsed else {
+        panic!("expected module");
+    };
+    let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] else {
+        panic!("expected function def");
+    };
+    let dec = &func_def.decorator_list[0];
+    let names: Vec<String> = decorators::extract_parametrize_argnames(dec, code)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    let indirect = decorators::extract_parametrize_indirect_names(dec, &names);
+    assert!(indirect.contains("a"));
+    assert!(indirect.contains("b"));
+}
+
+#[test]
+#[timeout(30000)]
+fn test_indirect_names_partial_list() {
+    let code = "@pytest.mark.parametrize('a,b', [(1, 2)], indirect=['a'])\ndef test_x(a, b): pass";
+    let parsed = parse(code, Mode::Module, "").unwrap();
+    let rustpython_parser::ast::Mod::Module(module) = parsed else {
+        panic!("expected module");
+    };
+    let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] else {
+        panic!("expected function def");
+    };
+    let dec = &func_def.decorator_list[0];
+    let names: Vec<String> = decorators::extract_parametrize_argnames(dec, code)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    let indirect = decorators::extract_parametrize_indirect_names(dec, &names);
+    assert!(indirect.contains("a"));
+    assert!(!indirect.contains("b"));
 }

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -7959,6 +7959,55 @@ def test_something(baz):
 
 #[tokio::test]
 #[timeout(30000)]
+async fn test_rename_respects_nested_scope_shadowing() {
+    // A comprehension loop var and a lambda param that reuse the name are different bindings and
+    // must not be renamed; a direct reference in the test body must be renamed.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [[1, 2]])
+def test_something(foo):
+    squared = [foo for foo in range(3)]
+    fn = lambda foo: foo + 1
+    assert foo
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [[1, 2]])
+def test_something(baz):
+    squared = [foo for foo in range(3)]
+    fn = lambda foo: foo + 1
+    assert baz
+"#;
+    // Trigger from the signature parameter (occ 1; occ 0 is the decorator string).
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_shadow")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_indirect_list_form_declined() {
+    // `indirect=["foo"]` with list argnames must be detected and declined (review finding 3).
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize(["foo", "bar"], [(1, 2)], indirect=["foo"])
+def test_something(foo, bar):
+    print(foo, bar)
+"#;
+    let got =
+        run_parametrize_rename(content, "foo", 1, "renamed", "test_rename_indirect_list").await;
+    assert!(
+        got.is_none(),
+        "indirect param via list argnames should be declined"
+    );
+}
+
+#[tokio::test]
+#[timeout(30000)]
 async fn test_rename_declines_indirect_parameter() {
     let content = r#"import pytest
 

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -7761,9 +7761,12 @@ async fn run_parametrize_rename(
     let backend = make_backend_with_db(db);
     let uri = Uri::from_file_path(&path).unwrap();
 
+    // Drive the public LSP trait method so the request wiring is exercised too.
+    use tower_lsp_server::LanguageServer;
+
     let position = position_of(content, trigger, occurrence);
     let ws = backend
-        .handle_rename(RenameParams {
+        .rename(RenameParams {
             text_document_position: TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier { uri },
                 position,
@@ -7774,7 +7777,7 @@ async fn run_parametrize_rename(
             },
         })
         .await
-        .expect("handle_rename should not error")?;
+        .expect("rename should not error")?;
 
     let edits = ws.changes.expect("rename should produce changes");
     let edits = edits.into_values().next().expect("one file of edits");
@@ -7960,15 +7963,25 @@ def test_something(baz):
 #[tokio::test]
 #[timeout(30000)]
 async fn test_rename_respects_nested_scope_shadowing() {
-    // A comprehension loop var and a lambda param that reuse the name are different bindings and
-    // must not be renamed; a direct reference in the test body must be renamed.
+    // Nested scopes that rebind the name (comprehension loop vars across all comprehension forms,
+    // a lambda param, a nested function param, and *args/**kwargs) bind a different variable and
+    // must not be renamed; a direct reference in the test body must be.
     let content = r#"import pytest
 
 
 @pytest.mark.parametrize("foo", [[1, 2]])
 def test_something(foo):
-    squared = [foo for foo in range(3)]
+    a = [foo for foo in range(3)]
+    b = {foo for foo in range(3)}
+    c = {foo: foo for foo in range(3)}
+    d = (foo for foo in range(3))
     fn = lambda foo: foo + 1
+    def inner(foo):
+        return foo
+    def variadic(*foo):
+        return foo
+    def kw_only(**foo):
+        return foo
     assert foo
 "#;
     let expected = r#"import pytest
@@ -7976,8 +7989,17 @@ def test_something(foo):
 
 @pytest.mark.parametrize("baz", [[1, 2]])
 def test_something(baz):
-    squared = [foo for foo in range(3)]
+    a = [foo for foo in range(3)]
+    b = {foo for foo in range(3)}
+    c = {foo: foo for foo in range(3)}
+    d = (foo for foo in range(3))
     fn = lambda foo: foo + 1
+    def inner(foo):
+        return foo
+    def variadic(*foo):
+        return foo
+    def kw_only(**foo):
+        return foo
     assert baz
 "#;
     // Trigger from the signature parameter (occ 1; occ 0 is the decorator string).
@@ -7985,6 +8007,186 @@ def test_something(baz):
         .await
         .expect("rename should produce edits");
     assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_renames_closures_and_nonshadowing_scopes() {
+    // Scopes that do NOT rebind the name reference the parametrize param: comprehension bodies,
+    // lambda bodies, and nested-function defaults and closures must all be renamed.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    e = [x + foo for x in range(3)]
+    g = lambda y: y + foo
+    def closure(y=foo):
+        return y + foo
+    assert foo
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    e = [x + baz for x in range(3)]
+    g = lambda y: y + baz
+    def closure(y=baz):
+        return y + baz
+    assert baz
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_closures")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_enclosing_scope_references_in_nested_signature() {
+    // Parts of a nested function evaluated in the enclosing scope (decorator, parameter
+    // annotations/defaults, return annotation) and a comprehension `if` condition reference the
+    // parametrize param and must be renamed, even though the nested body is its own scope.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    filtered = [x for x in items if x == foo]
+
+    @register(foo)
+    def helper(y: foo = foo, *args: foo) -> foo:
+        return y
+
+    assert foo
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    filtered = [x for x in items if x == baz]
+
+    @register(baz)
+    def helper(y: baz = baz, *args: baz) -> baz:
+        return y
+
+    assert baz
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_nested_sig")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_async_test_and_nested_async_function() {
+    // An async test and a nested async closure that references the param.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+async def test_something(foo):
+    async def inner():
+        return foo
+    assert foo
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+async def test_something(baz):
+    async def inner():
+        return baz
+    assert baz
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_async")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_comprehension_unpacking_targets_shadow() {
+    // Tuple and starred unpacking comprehension targets that bind the name must be left alone.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    a = [foo for foo, x in pairs]
+    b = [x for *foo, in chunks]
+    assert foo
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    a = [foo for foo, x in pairs]
+    b = [x for *foo, in chunks]
+    assert baz
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_unpack")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_triggered_at_end_of_identifier() {
+    // A caret resting just past the last character of the parameter must still resolve (the cursor
+    // position editors commonly use for rename).
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    print(foo)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    print(baz)
+"#;
+    // Position the caret immediately after `foo` in the signature.
+    let after_foo = {
+        let p = position_of(content, "foo", 1);
+        Position {
+            line: p.line,
+            character: p.character + 3,
+        }
+    };
+    use pytest_language_server::FixtureDatabase;
+    let db = Arc::new(FixtureDatabase::new());
+    let path = std::env::temp_dir()
+        .join("test_rename_caret_end")
+        .join("test_parametrize.py");
+    db.analyze_file(path.clone(), content);
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(&path).unwrap();
+    let ws = backend
+        .handle_rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: after_foo,
+            },
+            new_name: "baz".to_string(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        })
+        .await
+        .expect("handle_rename should not error")
+        .expect("caret at end of identifier should still rename");
+    let edits = ws.changes.unwrap().into_values().next().unwrap();
+    assert_eq!(apply_text_edits(content, &edits), expected);
 }
 
 #[tokio::test]
@@ -8004,6 +8206,45 @@ def test_something(foo, bar):
         got.is_none(),
         "indirect param via list argnames should be declined"
     );
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_declines_outside_function_and_on_syntax_error() {
+    use pytest_language_server::FixtureDatabase;
+    use tower_lsp_server::LanguageServer;
+
+    // Cursor at module level (not inside any function) is declined.
+    let module_level = "import pytest\n\nx = 1\n";
+    let got = run_parametrize_rename(module_level, "x", 0, "y", "test_rename_module_level").await;
+    assert!(got.is_none(), "module-level position should be declined");
+
+    // A file with a syntax error cannot be parsed, so rename is declined rather than erroring.
+    let broken = "import pytest\n\n@pytest.mark.parametrize(\"foo\", [1]\ndef test_x(foo):\n    print(foo)\n";
+    let got = run_parametrize_rename(broken, "foo", 1, "baz", "test_rename_broken").await;
+    assert!(got.is_none(), "unparseable file should be declined");
+
+    // A document the server has never analyzed has no cached content, so rename returns None.
+    let db = Arc::new(FixtureDatabase::new());
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(std::env::temp_dir().join("never_opened.py")).unwrap();
+    let result = backend
+        .rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            new_name: "baz".to_string(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        })
+        .await
+        .expect("rename should not error");
+    assert!(result.is_none(), "unanalyzed document should be declined");
 }
 
 #[tokio::test]
@@ -8106,12 +8347,14 @@ def test_something(my_fixture, foo):
     let backend = make_backend_with_db(db);
     let uri = Uri::from_file_path(&path).unwrap();
 
+    use tower_lsp_server::LanguageServer;
+
     let prepare = |pos: Position| {
         let backend = &backend;
         let uri = uri.clone();
         async move {
             backend
-                .handle_prepare_rename(TextDocumentPositionParams {
+                .prepare_rename(TextDocumentPositionParams {
                     text_document: TextDocumentIdentifier { uri },
                     position: pos,
                 })

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -7694,3 +7694,394 @@ def test_parametrized(request):
         content
     );
 }
+
+// ============================================================================
+// Rename: @pytest.mark.parametrize parameters (issue #165)
+// ============================================================================
+
+/// Byte-offset position of the `occurrence`-th match of `needle` in `content`.
+/// `character` is a byte column, matching the server's position convention.
+fn position_of(content: &str, needle: &str, occurrence: usize) -> Position {
+    let mut count = 0;
+    for (line_idx, line) in content.lines().enumerate() {
+        let mut start = 0;
+        while let Some(rel) = line[start..].find(needle) {
+            let col = start + rel;
+            if count == occurrence {
+                return Position {
+                    line: line_idx as u32,
+                    character: col as u32,
+                };
+            }
+            count += 1;
+            start = col + needle.len();
+        }
+    }
+    panic!("needle {needle:?} occurrence {occurrence} not found in content");
+}
+
+/// Apply LSP `TextEdit`s (single file, non-overlapping) to `content`.
+fn apply_text_edits(content: &str, edits: &[TextEdit]) -> String {
+    let mut line_starts = vec![0usize];
+    for (i, b) in content.bytes().enumerate() {
+        if b == b'\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let to_offset = |p: &Position| line_starts[p.line as usize] + p.character as usize;
+
+    let mut sorted: Vec<&TextEdit> = edits.iter().collect();
+    sorted.sort_by_key(|e| (e.range.start.line, e.range.start.character));
+
+    let mut result = content.to_string();
+    for e in sorted.iter().rev() {
+        let start = to_offset(&e.range.start);
+        let end = to_offset(&e.range.end);
+        result.replace_range(start..end, &e.new_text);
+    }
+    result
+}
+
+/// Run a rename at `(trigger, occurrence)` and return the rewritten file text, or `None` if the
+/// server declined the rename.
+async fn run_parametrize_rename(
+    content: &str,
+    trigger: &str,
+    occurrence: usize,
+    new_name: &str,
+    subdir: &str,
+) -> Option<String> {
+    use pytest_language_server::FixtureDatabase;
+
+    let db = Arc::new(FixtureDatabase::new());
+    let path = std::env::temp_dir()
+        .join(subdir)
+        .join("test_parametrize.py");
+    db.analyze_file(path.clone(), content);
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(&path).unwrap();
+
+    let position = position_of(content, trigger, occurrence);
+    let ws = backend
+        .handle_rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            new_name: new_name.to_string(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        })
+        .await
+        .expect("handle_rename should not error")?;
+
+    let edits = ws.changes.expect("rename should produce changes");
+    let edits = edits.into_values().next().expect("one file of edits");
+    Some(apply_text_edits(content, &edits))
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_single_from_all_three_sites() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", ["a", "b"])
+def test_something(foo):
+    print(foo)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("renamed", ["a", "b"])
+def test_something(renamed):
+    print(renamed)
+"#;
+
+    // Trigger from the decorator string (occ 0), the signature (occ 1), and the body (occ 2).
+    for (occ, where_) in [(0, "string"), (1, "signature"), (2, "body")] {
+        let got = run_parametrize_rename(content, "foo", occ, "renamed", "test_rename_single")
+            .await
+            .unwrap_or_else(|| panic!("rename from {where_} should produce edits"));
+        assert_eq!(got, expected, "rename triggered from {where_}");
+    }
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_comma_renames_only_target() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo, bar", [(1, 2)])
+def test_something(foo, bar):
+    print(foo, bar)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz, bar", [(1, 2)])
+def test_something(baz, bar):
+    print(baz, bar)
+"#;
+    // Trigger on the signature `foo` (occ 1); `bar` must stay untouched.
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_comma")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_list_form() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize(["foo", "bar"], [(1, 2)])
+def test_something(foo, bar):
+    print(foo)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize(["baz", "bar"], [(1, 2)])
+def test_something(baz, bar):
+    print(baz)
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_list")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_tuple_form() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize(("foo", "bar"), [(1, 2)])
+def test_something(foo, bar):
+    print(bar)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize(("foo", "baz"), [(1, 2)])
+def test_something(foo, baz):
+    print(baz)
+"#;
+    // Rename `bar` from its body usage (occ 1; occ 0 is the decorator string).
+    let got = run_parametrize_rename(content, "bar", 1, "baz", "test_rename_tuple")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_argnames_keyword() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize(argnames="foo", argvalues=[1, 2])
+def test_something(foo):
+    print(foo)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize(argnames="renamed", argvalues=[1, 2])
+def test_something(renamed):
+    print(renamed)
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "renamed", "test_rename_kwarg")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_stacked_decorators() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+@pytest.mark.parametrize("bar", [2])
+def test_something(foo, bar):
+    print(foo, bar)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+@pytest.mark.parametrize("renamed", [2])
+def test_something(foo, renamed):
+    print(foo, renamed)
+"#;
+    // Rename `bar` (declared in the second decorator) from its signature occurrence (occ 1).
+    let got = run_parametrize_rename(content, "bar", 1, "renamed", "test_rename_stacked")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_body_attribute_and_string_untouched() {
+    // The name must not be renamed where it appears as an attribute, a string, or a keyword-arg
+    // name in the body — only as a bare local reference.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    obj.foo = foo
+    helper(foo="literal")
+    print("foo", foo)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    obj.foo = baz
+    helper(foo="literal")
+    print("foo", baz)
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_body")
+        .await
+        .expect("rename should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_declines_indirect_parameter() {
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", ["a"], indirect=True)
+def test_something(foo):
+    print(foo)
+"#;
+    let got = run_parametrize_rename(content, "foo", 1, "renamed", "test_rename_indirect").await;
+    assert!(
+        got.is_none(),
+        "indirect parametrize param should not be renamed"
+    );
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_declines_fixture_parameter() {
+    let content = r#"import pytest
+
+
+@pytest.fixture
+def my_fixture():
+    return 1
+
+
+def test_something(my_fixture):
+    print(my_fixture)
+"#;
+    let got =
+        run_parametrize_rename(content, "my_fixture", 1, "renamed", "test_rename_fixture").await;
+    assert!(
+        got.is_none(),
+        "fixture parameters are out of scope for this provider"
+    );
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_rejects_invalid_identifier() {
+    use pytest_language_server::FixtureDatabase;
+
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    print(foo)
+"#;
+    let db = Arc::new(FixtureDatabase::new());
+    let path = std::env::temp_dir()
+        .join("test_rename_invalid")
+        .join("test_parametrize.py");
+    db.analyze_file(path.clone(), content);
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(&path).unwrap();
+
+    let result = backend
+        .handle_rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: position_of(content, "foo", 1),
+            },
+            new_name: "1invalid".to_string(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        })
+        .await;
+
+    assert!(result.is_err(), "invalid identifier should be rejected");
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_prepare_rename_parametrize_vs_fixture() {
+    use pytest_language_server::FixtureDatabase;
+
+    let content = r#"import pytest
+
+
+@pytest.fixture
+def my_fixture():
+    return 1
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(my_fixture, foo):
+    print(my_fixture, foo)
+"#;
+    let db = Arc::new(FixtureDatabase::new());
+    let path = std::env::temp_dir()
+        .join("test_prepare_rename")
+        .join("test_parametrize.py");
+    db.analyze_file(path.clone(), content);
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(&path).unwrap();
+
+    let prepare = |pos: Position| {
+        let backend = &backend;
+        let uri = uri.clone();
+        async move {
+            backend
+                .handle_prepare_rename(TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position: pos,
+                })
+                .await
+                .unwrap()
+        }
+    };
+
+    // On the parametrize param: returns a range.
+    let on_param = prepare(position_of(content, "foo", 1)).await;
+    assert!(
+        matches!(on_param, Some(PrepareRenameResponse::Range(_))),
+        "prepare_rename on a parametrize param should return a range, got {on_param:?}"
+    );
+
+    // On a plain fixture param: declined.
+    let on_fixture = prepare(position_of(content, "my_fixture", 1)).await;
+    assert!(
+        on_fixture.is_none(),
+        "prepare_rename on a fixture param should be declined"
+    );
+}

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -7699,21 +7699,29 @@ def test_parametrized(request):
 // Rename: @pytest.mark.parametrize parameters (issue #165)
 // ============================================================================
 
-/// Byte-offset position of the `occurrence`-th match of `needle` in `content`.
-/// `character` is a byte column, matching the server's position convention.
+/// Byte-offset position of the `occurrence`-th *whole-word* match of `needle` in `content`.
+/// `character` is a byte column, matching the server's position convention. Matches that are part
+/// of a larger identifier are skipped so a test never silently triggers on the wrong token.
 fn position_of(content: &str, needle: &str, occurrence: usize) -> Position {
+    let is_word = |b: u8| b == b'_' || b.is_ascii_alphanumeric();
     let mut count = 0;
     for (line_idx, line) in content.lines().enumerate() {
+        let bytes = line.as_bytes();
         let mut start = 0;
         while let Some(rel) = line[start..].find(needle) {
             let col = start + rel;
-            if count == occurrence {
-                return Position {
-                    line: line_idx as u32,
-                    character: col as u32,
-                };
+            let end = col + needle.len();
+            let whole_word = (col == 0 || !is_word(bytes[col - 1]))
+                && (end >= bytes.len() || !is_word(bytes[end]));
+            if whole_word {
+                if count == occurrence {
+                    return Position {
+                        line: line_idx as u32,
+                        character: col as u32,
+                    };
+                }
+                count += 1;
             }
-            count += 1;
             start = col + needle.len();
         }
     }
@@ -7935,7 +7943,7 @@ def test_something(foo, renamed):
 #[timeout(30000)]
 async fn test_rename_parametrize_body_attribute_and_string_untouched() {
     // The name must not be renamed where it appears as an attribute, a string, or a keyword-arg
-    // name in the body — only as a bare local reference.
+    // name in the body, nor inside a larger identifier (foobar) — only as a bare local reference.
     let content = r#"import pytest
 
 
@@ -7943,7 +7951,8 @@ async fn test_rename_parametrize_body_attribute_and_string_untouched() {
 def test_something(foo):
     obj.foo = foo
     helper(foo="literal")
-    print("foo", foo)
+    foobar = foo
+    print("foo", foo, foobar)
 "#;
     let expected = r#"import pytest
 
@@ -7952,7 +7961,8 @@ def test_something(foo):
 def test_something(baz):
     obj.foo = baz
     helper(foo="literal")
-    print("foo", baz)
+    foobar = baz
+    print("foo", baz, foobar)
 "#;
     let got = run_parametrize_rename(content, "foo", 1, "baz", "test_rename_body")
         .await

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -8092,6 +8092,37 @@ def test_something(baz):
 
 #[tokio::test]
 #[timeout(30000)]
+async fn test_rename_triggered_from_inside_nested_closure() {
+    // Invoking rename on the parameter from inside a nested closure (whose own def has no
+    // parametrize decorator) must still resolve to the enclosing parametrized test and rewrite
+    // the decorator string, signature, and all references.
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("foo", [1])
+def test_something(foo):
+    def closure():
+        return foo
+    return closure()
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("baz", [1])
+def test_something(baz):
+    def closure():
+        return baz
+    return closure()
+"#;
+    // `foo` occurrences: decorator string (0), signature (1), closure body (2).
+    let got = run_parametrize_rename(content, "foo", 2, "baz", "test_rename_from_closure")
+        .await
+        .expect("rename from a closure reference should produce edits");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+#[timeout(30000)]
 async fn test_rename_async_test_and_nested_async_function() {
     // An async test and a nested async closure that references the param.
     let content = r#"import pytest

--- a/tests/test_project/test_parametrize.py
+++ b/tests/test_project/test_parametrize.py
@@ -1,0 +1,34 @@
+"""Sample tests exercising the @pytest.mark.parametrize argname forms."""
+
+import pytest
+
+
+@pytest.mark.parametrize("value", ["a", "b"])
+def test_single(value):
+    assert value
+
+
+@pytest.mark.parametrize("left, right", [(1, 2), (3, 4)])
+def test_comma(left, right):
+    assert left < right
+
+
+@pytest.mark.parametrize(["first", "second"], [(1, 2)])
+def test_list_form(first, second):
+    assert first != second
+
+
+@pytest.mark.parametrize(("alpha", "beta"), [(1, 2)])
+def test_tuple_form(alpha, beta):
+    assert alpha + beta
+
+
+@pytest.mark.parametrize(argnames="kw", argvalues=[1, 2])
+def test_keyword_form(kw):
+    assert kw
+
+
+@pytest.mark.parametrize("outer", [1])
+@pytest.mark.parametrize("inner", [2])
+def test_stacked(outer, inner):
+    assert outer != inner


### PR DESCRIPTION
Closes #165.

Renaming a parametrized parameter now updates the name in the `@pytest.mark.parametrize(...)` decorator string, the test signature, and the test body in one edit. The rename works from any of those three spots, matching what PyCharm does. There was no rename provider before this.

## Scope and design

This server runs alongside a general Python LSP, so the design avoids stepping on it:

- Only parametrize parameters are renamed. On a fixture or any other symbol, `prepareRename`/`rename` return nothing, so pyright/pylsp answers instead.
- `indirect=True` parameters are skipped. They route to a fixture, and a local-only rename would quietly break the test.
- The edit is self-contained (decorator string + signature + body), so it produces correct code when this server is the only one handling rename.

## What it handles

All argname forms: a single name, a comma string (`"a,b"` and `"a, b"`), a list, a tuple, and the `argnames=` keyword. Stacked parametrize decorators work too. Attribute access (`obj.foo`), string literals, and keyword-arg names in the body are left alone since they aren't references to the parameter.

Body usages are collected with the generated `rustpython-ast` `Visitor` (enabled via the `visitor` feature) rather than a hand-rolled walk, so no node type slips through and leaves a stale reference.

Known gap: a nested scope inside the test body that shadows the parameter name will be over-collected. It doesn't happen in practice.

## Tests

- `tests/test_decorators.rs`: argname extraction for every form, asserting the ranges land on the identifier and not the quotes or whitespace.
- `tests/test_lsp.rs`: rename across all forms and all three trigger sites, stacked decorators, plus the guards (indirect, fixture, invalid identifier, prepareRename).
- `tests/test_project/test_parametrize.py`: sample file for the end-to-end scans.