### PR TITLE
ci: aggregate cross-OS coverage via cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -31,7 +35,9 @@ jobs:
           components: rustfmt, clippy, llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
+          components: rustfmt, clippy, llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -44,42 +47,15 @@ jobs:
       - name: Build
         run: cargo build --release --verbose
 
-      - name: Build binary for tests
-        run: cargo build
-
-
-      - name: Run tests
-        run: cargo test --verbose
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "coverage"
-
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-
-      - name: Build binary for tests
-        run: cargo build
-
-
-      - name: Generate coverage report
-        run: cargo tarpaulin --out Xml --skip-clean
+      - name: Run tests with coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: cobertura.xml
+          files: lcov.info
+          flags: os-${{ runner.os }}
           fail_ci_if_error: false
 
   check-msrv:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,15 +7,8 @@ coverage:
 
 flags:
   os-Linux:
-    paths:
-      - src/
+    carryforward: true
   os-macOS:
-    paths:
-      - src/
+    carryforward: true
   os-Windows:
-    paths:
-      - src/
-
-codecov:
-  notify:
-    after_n_builds: 3
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  os-Linux:
+    paths:
+      - src/
+  os-macOS:
+    paths:
+      - src/
+  os-Windows:
+    paths:
+      - src/
+
+codecov:
+  notify:
+    after_n_builds: 3


### PR DESCRIPTION
## Why

The `coverage` job ran `cargo-tarpaulin` on `ubuntu-latest` only, because tarpaulin is Linux-only (ptrace-based) and can't join the test matrix. Two problems followed:

1. Coverage reflected Linux execution only. OS-specific branches were never counted, e.g. the `cfg!(target_os = "macos")` / `"windows"` arms in `src/providers/mod.rs:90-102` and `#[cfg(unix)]` in `scanner.rs`. Codecov reported a Linux number, not the project's.
2. The test suite ran twice per commit: once in `test` across all three OSes, then again from scratch under tarpaulin.

## Changes

- Swap tarpaulin for `cargo-llvm-cov` (source-based, cross-platform) and fold coverage into the `test` matrix, so tests run once per OS and emit coverage in the same pass.
- Each OS uploads its own report tagged `flags: os-${{ runner.os }}`. Codecov merges the per-commit reports into one aggregated figure that includes the OS-specific branches. `carryforward: true` on each flag (in the new `codecov.yml`) keeps the merged number stable if one OS upload is missing, instead of letting it drop.
- Drop the standalone `coverage` job and the now-redundant `cargo build` step (llvm-cov builds its own instrumented binary in a separate target dir).

The e2e tests that shell out to the binary now count toward coverage too: `assert_cmd::Command::cargo_bin` resolves `CARGO_BIN_EXE_*` to llvm-cov's instrumented build. Tarpaulin missed those.

## Verification

Real check is this PR's own run: confirm the `test` job collects coverage on all three OSes, the old job is gone, Codecov receives three uploads, and the macOS/Windows arms in `src/providers/mod.rs` now show as covered.
