### PR TITLE
fix: clear security advisories and stop VSCode dependabot churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,10 +51,22 @@ updates:
     commit-message:
       prefix: "deps(vscode)"
       include: "scope"
+    ignore:
+      # engines.vscode is our VSCodium support floor, not a dependency.
+      # @types/vscode is pinned exactly to it; bump both by hand, together,
+      # after checking github.com/VSCodium/vscodium/releases. See issue #144.
+      - dependency-name: "@types/vscode"
+      # typescript-eslint peer-caps typescript at <6.1.0, so TS7 breaks
+      # npm install. Drop this once typescript-eslint supports TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
-      npm-all:
+      npm-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Gradle dependencies (IntelliJ plugin)
   - package-ecosystem: "gradle"

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -8,6 +8,7 @@ license_check: true
 allow_licenses:
   - MIT
   - Apache-2.0
+  - BlueOak-1.0.0
   - BSD-2-Clause
   - BSD-3-Clause
   - ISC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
           npm install
           npm install -g @vscode/vsce
 
+      - name: Check dependency engines against VSCodium floor
+        run: |
+          cd extensions/vscode-extension
+          npm run check-engines
+
       - name: Lint
         run: |
           cd extensions/vscode-extension

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,27 @@ When adding new LSP features, update the feature lists in all extension READMEs:
 
 Keep them in sync with the main `README.md` features section.
 
+### VSCode Extension: the VSCodium support floor
+`engines.vscode` is a product decision (oldest VSCodium we support), not a dependency. VSCodium
+skips releases and trails VS Code by 4-6 minors for weeks, so tracking the newest `@types/vscode`
+makes the extension uninstallable there — that was issue #144.
+
+Rules:
+- `@types/vscode` is pinned **exactly** to the highest version published at or below
+  `engines.vscode` (DefinitelyTyped doesn't publish one per VS Code release — there is no 1.112.0,
+  so a `^1.112.0` floor pins `1.110.0`). Never use a caret: `vsce` validates the *declared range*,
+  not the resolved version, so a caret lets npm install types above the floor with `vsce` none the
+  wiser. Exact pinning makes `tsc` reject any API newer than the floor — that is the real guard.
+- Move `engines.vscode` and `@types/vscode` together, by hand, after checking
+  [VSCodium releases](https://github.com/VSCodium/vscodium/releases). Dependabot ignores both.
+- Runtime deps declare their own `engines.vscode`; `npm run check-engines` fails if one exceeds
+  ours. `vsce` does not check this.
+- Everything else (eslint, typescript, webpack, ts-loader, @types/node) is build-time only and
+  cannot reach VSCodium users.
+- `tsconfig.json` must keep `"types": ["node"]`. The extension imports `path`/`fs` and uses
+  `process`/`console`; before vscode-languageclient v10 those types leaked in via the library's
+  `/// <reference types="node" />`, which v10 removed.
+
 ### Imported Fixtures
 Fixtures imported via star imports in `conftest.py` are discovered:
 ```python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/extensions/vscode-extension/.vscodeignore
+++ b/extensions/vscode-extension/.vscodeignore
@@ -1,9 +1,11 @@
 .vscode/**
 .vscode-test/**
 src/**
+scripts/**
 .gitignore
 .yarnrc
 webpack.config.js
+eslint.config.mjs
 **/tsconfig.json
 **/.eslintrc.json
 out/**/*.map

--- a/extensions/vscode-extension/package-lock.json
+++ b/extensions/vscode-extension/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "pytest-language-server",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-language-server",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageclient": "^9.0.0"
+        "vscode-languageclient": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
-        "@types/vscode": "^1.112.0",
+        "@types/vscode": "1.110.0",
         "eslint": "^10.2.1",
         "ts-loader": "^9.5.7",
         "typescript": "^6.0.3",
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.116.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
-      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
       "dev": true,
       "license": "MIT"
     },
@@ -832,12 +832,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -846,15 +840,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -1762,13 +1747,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1781,7 +1765,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1791,7 +1774,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2149,9 +2131,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2515,54 +2497,49 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.82.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/watchpack": {

--- a/extensions/vscode-extension/package-lock.json
+++ b/extensions/vscode-extension/package-lock.json
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -832,6 +832,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -840,6 +849,18 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1761,27 +1782,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/vscode-extension/package.json
+++ b/extensions/vscode-extension/package.json
@@ -89,12 +89,13 @@
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "check-engines": "node scripts/check-engines.js"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
-    "@types/vscode": "^1.112.0",
+    "@types/vscode": "1.110.0",
     "eslint": "^10.2.1",
     "ts-loader": "^9.5.7",
     "typescript": "^6.0.3",
@@ -103,6 +104,6 @@
     "webpack-cli": "^7.0.2"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.0"
+    "vscode-languageclient": "^10.1.0"
   }
 }

--- a/extensions/vscode-extension/scripts/check-engines.js
+++ b/extensions/vscode-extension/scripts/check-engines.js
@@ -1,0 +1,34 @@
+// Fails if a runtime dependency requires a newer VS Code than engines.vscode
+// declares. vsce only checks @types/vscode, so without this a languageclient
+// bump can ship an extension that installs on VSCodium and dies at runtime.
+//
+// ponytail: direct runtime deps only, assumes "^1.X.Y" — vscode-languageclient
+// is the only vscode-gated dep. Walk node_modules if that stops being true.
+const pkg = require('../package.json');
+
+const parse = (range) => {
+  const m = /(\d+)\.(\d+)/.exec(range);
+  if (!m) throw new Error(`cannot parse vscode range: ${range}`);
+  return [Number(m[1]), Number(m[2])];
+};
+
+const floor = parse(pkg.engines.vscode);
+
+let bad = false;
+for (const dep of Object.keys(pkg.dependencies ?? {})) {
+  const req = require(`../node_modules/${dep}/package.json`).engines?.vscode;
+  if (!req) continue;
+
+  const need = parse(req);
+  if (need[0] > floor[0] || (need[0] === floor[0] && need[1] > floor[1])) {
+    console.error(
+      `${dep} requires vscode ${req}, above engines.vscode ${pkg.engines.vscode}. ` +
+      `Raising the floor drops VSCodium users — check https://github.com/VSCodium/vscodium/releases first.`
+    );
+    bad = true;
+  } else {
+    console.log(`${dep} requires vscode ${req} — within ${pkg.engines.vscode}`);
+  }
+}
+
+process.exit(bad ? 1 : 0);

--- a/extensions/vscode-extension/tsconfig.json
+++ b/extensions/vscode-extension/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "ES2020",
     "lib": ["ES2020"],
+    "types": ["node"],
     "outDir": "out",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Two unrelated fixes, both in dependency plumbing.

## Security jobs

`Security Audit` and `Cargo Deny` fail on every PR against two transitive crates:

- RUSTSEC-2026-0204: crossbeam-epoch 0.9.18, vulnerability, via rayon
- RUSTSEC-2026-0190: anyhow 1.0.100, unsound, build-dep of rustpython-parser

Lockfile only, both semver-compatible. Dependabot never proposed either because the cargo ecosystem
tracks direct deps from `Cargo.toml` only, so lockfile-only crates sit until someone runs
`cargo update`. After this, `cargo audit` reports 0 vulnerabilities (7 allowed unmaintained
warnings) and `cargo deny check` passes.

## VSCode extension dependencies

#150 through #184: ten `npm-all` group PRs in a row, all closed. The group matched every update
type, so one weekly PR bundled build-time devDep patches together with `@types/vscode`,
`vscode-languageclient` and `typescript` majors. One bad entry cost the whole PR.

`engines.vscode` is a support floor, not a dependency:

- `@types/vscode` pinned exactly to `1.110.0`, the highest published at or below the `^1.112.0`
  floor. DefinitelyTyped skips releases, so there is no 1.112.0.
- Dependabot ignores `@types/vscode`. Move it and `engines.vscode` by hand, together, after
  checking VSCodium's releases (issue #144).
- The npm group now takes minor/patch only, so majors arrive as their own PRs.

The old caret hid a live bug. `vsce` validates the declared range rather than the resolved version,
so `^1.112.0` passed while npm installed 1.116.0: master compiles against APIs VSCodium 1.112 does
not ship. An exact pin makes declared and installed agree, which lets `tsc` reject anything above
the floor.

`npm run check-engines` is new and runs in the existing Check VSCode Extension job. It fails when a
runtime dep declares a higher `engines.vscode` than ours, which `vsce` does not check.

Two version moves ride along:

- `vscode-languageclient` 9 to 10. It needs `^1.91.0` and fits under the floor. v10 drops the
  `/// <reference types="node" />` that the extension was relying on for `path`, `fs`, `process`
  and `console`, so `tsconfig.json` now declares `"types": ["node"]` directly.
- `typescript` stays at 6. No published `typescript-eslint` supports TS7, stable and canary both
  peer at `>=4.8.4 <6.1.0`, so the bump fails `npm install`. Dependabot ignores the major until
  that changes.

Moving to languageclient 10 pulls `minimatch` to 10.2.5, which surfaced two Dependency Review
failures. Both are handled here:

- `brace-expansion` 5.0.5 has a moderate DoS advisory (GHSA-jxxr-4gwj-5jf2). It predates this
  branch and only got flagged once minimatch moved, since dependency-review inspects changed deps
  only. Bumped to the patched 5.0.7, `npm audit` reports zero.
- `minimatch` 10.x is BlueOak-1.0.0, absent from `allow_licenses`. The license is permissive and
  OSI-approved: unrestricted copyright grant, an explicit patent grant, and a notice requirement
  matching MIT's. It is more permissive than MPL-2.0, already on the list. Added rather than worked
  around.

## Verification

`cargo audit`, `cargo deny check`, `cargo test` (1286 passed), `cargo clippy`. For the extension,
from a clean `node_modules`: `npm install` (no ERESOLVE), `check-engines`, `lint`, `compile`,
`vsce package`. The guard was checked in both directions: it passes at `^1.112.0` and exits 1
naming `vscode-languageclient` when the floor is dropped to `^1.85.0`.
