### PR TITLE
fix: LSP position encoding, resolver correctness, and hot-path performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd extensions/vscode-extension
-          npm install
+          npm ci
           npm install -g @vscode/vsce
 
       - name: Check dependency engines against VSCodium floor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,24 @@ permissions:
   id-token: write
 
 jobs:
+  test:
+    name: Test & lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-test"
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test
+
   linux:
     runs-on: ubuntu-22.04
     strategy:
@@ -158,7 +176,7 @@ jobs:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-binaries]
+    needs: [test, build-binaries]
     permissions:
       contents: write
     steps:
@@ -239,7 +257,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, musllinux, windows, windows-freethreaded, macos, sdist, build-binaries, update-homebrew-formula]
+    needs: [test, linux, musllinux, windows, windows-freethreaded, macos, sdist, build-binaries, update-homebrew-formula]
     permissions:
       id-token: write
       contents: write
@@ -298,6 +316,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    needs: [test]
     permissions:
       contents: read
     steps:
@@ -309,7 +328,7 @@ jobs:
         with:
           shared-key: "publish-crates"
       - name: Publish to crates.io
-        run: cargo publish --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   build-binaries:
     name: Build standalone binaries for extensions
@@ -371,7 +390,7 @@ jobs:
     name: Publish VSCode extension
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-binaries]
+    needs: [test, build-binaries]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -392,7 +411,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd extensions/vscode-extension
-          npm install
+          npm ci
           npm install -g @vscode/vsce
       - name: Package extension
         run: |
@@ -407,7 +426,7 @@ jobs:
     name: Publish to Open VSX Registry
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-binaries]
+    needs: [test, build-binaries]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -428,7 +447,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd extensions/vscode-extension
-          npm install
+          npm ci
           npm install -g @vscode/vsce ovsx
       - name: Package extension
         run: |
@@ -443,7 +462,7 @@ jobs:
     name: Publish IntelliJ/PyCharm plugin
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-binaries]
+    needs: [test, build-binaries]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,6 +554,7 @@ jobs:
   publish-zed:
     name: Publish Zed extension
     runs-on: ubuntu-latest
+    needs: [test]
     # Disabled due to bug in huacnlee/zed-extension-action - regex doesn't handle multiline TOML
     # Manually update version in bellini666/extensions repository after each release
     if: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,6 @@ dependencies = [
  "insta",
  "memchr",
  "ntest",
- "once_cell",
  "predicates",
  "rayon",
  "rustpython-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ rustpython-parser = "0.4.0"
 rustpython-ast = { version = "0.4.0", features = ["visitor"] }
 walkdir = "2.5"
 dashmap = "6.2"
-once_cell = "1.21"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
@@ -44,3 +43,8 @@ assert_cmd = "2.2"
 predicates = "3.1"
 tempfile = "3.27.0"
 ntest = "0.9"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/README.md
+++ b/README.md
@@ -429,11 +429,9 @@ exclude = ["build/**", "dist/**", ".tox/**"]
 # Valid codes: "undeclared-fixture", "scope-mismatch", "circular-dependency"
 disabled_diagnostics = ["undeclared-fixture"]
 
-# Additional directories to scan for fixtures (planned feature)
-fixture_paths = ["fixtures/", "shared/fixtures/"]
-
-# Third-party plugins to skip when scanning venv (planned feature)
-skip_plugins = ["pytest-xdist"]
+# NOT IMPLEMENTED YET — accepted but ignored (a warning is logged):
+# fixture_paths = ["fixtures/", "shared/fixtures/"]
+# skip_plugins = ["pytest-xdist"]
 ```
 
 **Available Options:**

--- a/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLanguageServerService.kt
+++ b/extensions/intellij-plugin/src/main/java/com/github/bellini666/pytestlsp/PytestLanguageServerService.kt
@@ -7,8 +7,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 @Service(Service.Level.PROJECT)
 class PytestLanguageServerService(private val project: Project) {

--- a/extensions/vscode-extension/src/extension.ts
+++ b/extensions/vscode-extension/src/extension.ts
@@ -9,6 +9,16 @@ import {
 
 let client: LanguageClient | undefined;
 
+/** Detect musl-based Linux (no glibc runtime in the process report). */
+function isMusl(): boolean {
+  try {
+    const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } };
+    return report?.header?.glibcVersionRuntime === undefined;
+  } catch {
+    return false;
+  }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('pytestLanguageServer');
   const customExecutable = config.get<string>('executable', '');
@@ -25,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let binaryName: string;
     if (platform === 'win32') {
+      // Windows arm64 can run the x64 binary through emulation.
       binaryName = 'pytest-language-server.exe';
     } else if (platform === 'darwin') {
       // macOS
@@ -34,6 +45,21 @@ export async function activate(context: vscode.ExtensionContext) {
         binaryName = 'pytest-language-server-x86_64-apple-darwin';
       }
     } else if (platform === 'linux') {
+      if (arch !== 'arm64' && arch !== 'x64') {
+        vscode.window.showErrorMessage(
+          `Unsupported architecture: linux/${arch}. Please install pytest-language-server manually ` +
+          `(e.g. "pip install pytest-language-server") and set "pytestLanguageServer.executable".`
+        );
+        return;
+      }
+      if (isMusl()) {
+        vscode.window.showErrorMessage(
+          'The bundled pytest-language-server binary is built against glibc and will not run on ' +
+          'musl-based systems (e.g. Alpine). Please install pytest-language-server manually ' +
+          '(e.g. "pip install pytest-language-server") and set "pytestLanguageServer.executable".'
+        );
+        return;
+      }
       if (arch === 'arm64') {
         binaryName = 'pytest-language-server-aarch64-unknown-linux-gnu';
       } else {
@@ -109,6 +135,29 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       }
     })
+  );
+
+  // Register the command emitted by the server's code lenses ("N usages"):
+  // resolve references at the lens position and show them in the peek view.
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'pytest-lsp.findReferences',
+      async (uriString: string, line: number, character: number) => {
+        const uri = vscode.Uri.parse(uriString);
+        const position = new vscode.Position(line, character);
+        const locations = await vscode.commands.executeCommand<vscode.Location[]>(
+          'vscode.executeReferenceProvider',
+          uri,
+          position
+        );
+        await vscode.commands.executeCommand(
+          'editor.action.showReferences',
+          uri,
+          position,
+          locations ?? []
+        );
+      }
+    )
   );
 
   // Start the language server with proper error handling

--- a/extensions/vscode-extension/src/extension.ts
+++ b/extensions/vscode-extension/src/extension.ts
@@ -9,11 +9,18 @@ import {
 
 let client: LanguageClient | undefined;
 
-/** Detect musl-based Linux (no glibc runtime in the process report). */
+/** Detect musl-based Linux (report present but no glibc runtime in it).
+ * Unknown (no report/header available) is treated as glibc so we never
+ * block a working system on missing information. */
 function isMusl(): boolean {
   try {
-    const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } };
-    return report?.header?.glibcVersionRuntime === undefined;
+    const report = process.report?.getReport() as
+      | { header?: { glibcVersionRuntime?: string } }
+      | undefined;
+    if (!report?.header) {
+      return false;
+    }
+    return report.header.glibcVersionRuntime === undefined;
   } catch {
     return false;
   }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -131,6 +131,21 @@ impl Config {
             })
             .collect();
 
+        // These options are accepted but not implemented yet; warn instead of
+        // silently ignoring the user's configuration.
+        if !raw.fixture_paths.is_empty() {
+            warn!(
+                "'fixture_paths' in {:?} is not implemented yet and will be ignored",
+                path
+            );
+        }
+        if !raw.skip_plugins.is_empty() {
+            warn!(
+                "'skip_plugins' in {:?} is not implemented yet and will be ignored",
+                path
+            );
+        }
+
         debug!(
             "Loaded config from {:?}: {} exclude patterns, {} disabled diagnostics",
             path,

--- a/src/fixtures/analyzer.rs
+++ b/src/fixtures/analyzer.rs
@@ -7,7 +7,6 @@
 use super::decorators;
 use super::types::{FixtureDefinition, FixtureUsage, TypeImportSpec};
 use super::FixtureDatabase;
-use once_cell::sync::Lazy;
 use rustpython_parser::ast::{ArgWithDefault, Arguments, Expr, Stmt};
 use rustpython_parser::{parse, Mode};
 use std::collections::{HashMap, HashSet};
@@ -39,9 +38,10 @@ impl FixtureDatabase {
         self.file_cache
             .insert(file_path.clone(), std::sync::Arc::new(content.to_string()));
 
-        // Parse the Python code
+        // Parse the Python code and populate the AST cache so follow-up
+        // requests (completion, hover, code actions) don't re-parse.
         let parsed = match parse(content, Mode::Module, "") {
-            Ok(ast) => ast,
+            Ok(ast) => std::sync::Arc::new(ast),
             Err(e) => {
                 // Keep existing fixture data when parse fails (user is likely editing)
                 // This provides better LSP experience during editing with syntax errors
@@ -52,6 +52,11 @@ impl FixtureDatabase {
                 return;
             }
         };
+        let content_hash = Self::hash_content(content);
+        self.ast_cache.insert(
+            file_path.clone(),
+            (content_hash, std::sync::Arc::clone(&parsed)),
+        );
 
         // Clear previous usages for this file (only after successful parse)
         self.cleanup_usages_for_file(&file_path);
@@ -84,7 +89,7 @@ impl FixtureDatabase {
         let line_index = self.get_line_index(&file_path, content);
 
         // Process each statement in the module
-        if let rustpython_parser::ast::Mod::Module(module) = parsed {
+        if let rustpython_parser::ast::Mod::Module(module) = parsed.as_ref() {
             debug!("Module has {} statements", module.body.len());
 
             // First pass: collect all module-level names (imports, assignments, function/class defs)
@@ -101,8 +106,13 @@ impl FixtureDatabase {
                 .insert(file_path.clone(), module_level_names.clone());
 
             // Build a name→TypeImportSpec map from every import statement in the file.
-            // Used during fixture analysis to resolve return-type annotation imports.
+            // Used during fixture analysis to resolve return-type annotation imports,
+            // and cached for code-action and inlay-hint requests.
             let import_map = self.build_name_to_import_map(&module.body, &file_path);
+            self.name_import_map_cache.insert(
+                file_path.clone(),
+                (content_hash, std::sync::Arc::new(import_map.clone())),
+            );
 
             // Collect type aliases so that `-> MyType` can be expanded to the
             // underlying type before import resolution.
@@ -126,7 +136,7 @@ impl FixtureDatabase {
         debug!("Analysis complete for {:?}", file_path);
 
         // Periodically evict cache entries to prevent unbounded memory growth
-        self.evict_cache_if_needed();
+        self.evict_cache_if_needed(&file_path);
     }
 
     /// Remove definitions that were in a specific file.
@@ -322,7 +332,12 @@ impl FixtureDatabase {
                 |target| matches!(target, Expr::Name(name) if name.id.as_str() == "pytestmark"),
             );
             if is_pytestmark {
-                self.visit_pytestmark_assignment(Some(&assign.value), file_path, line_index);
+                self.visit_pytestmark_assignment(
+                    Some(&assign.value),
+                    file_path,
+                    content,
+                    line_index,
+                );
             }
         }
 
@@ -336,6 +351,7 @@ impl FixtureDatabase {
                 self.visit_pytestmark_assignment(
                     ann_assign.value.as_deref(),
                     file_path,
+                    content,
                     line_index,
                 );
             }
@@ -345,7 +361,7 @@ impl FixtureDatabase {
         if let Stmt::ClassDef(class_def) = stmt {
             // Check for @pytest.mark.usefixtures decorator on the class
             for decorator in &class_def.decorator_list {
-                let usefixtures = decorators::extract_usefixtures_names(decorator);
+                let usefixtures = decorators::extract_usefixtures_names(decorator, content);
                 for (fixture_name, range) in usefixtures {
                     let usage_line =
                         self.get_line_from_offset(range.start().to_usize(), line_index);
@@ -363,8 +379,8 @@ impl FixtureDatabase {
                         file_path,
                         fixture_name,
                         usage_line,
-                        start_char + 1,
-                        end_char - 1,
+                        start_char,
+                        end_char,
                         false, // usefixtures string — not a function parameter
                     );
                 }
@@ -410,7 +426,7 @@ impl FixtureDatabase {
 
         // Check for @pytest.mark.usefixtures decorator on the function
         for decorator in decorator_list {
-            let usefixtures = decorators::extract_usefixtures_names(decorator);
+            let usefixtures = decorators::extract_usefixtures_names(decorator, content);
             for (fixture_name, range) in usefixtures {
                 let usage_line = self.get_line_from_offset(range.start().to_usize(), line_index);
                 let start_char =
@@ -427,8 +443,8 @@ impl FixtureDatabase {
                     file_path,
                     fixture_name,
                     usage_line,
-                    start_char + 1,
-                    end_char - 1,
+                    start_char,
+                    end_char,
                     false, // usefixtures string — not a function parameter
                 );
             }
@@ -436,7 +452,8 @@ impl FixtureDatabase {
 
         // Check for @pytest.mark.parametrize with indirect=True on the function
         for decorator in decorator_list {
-            let indirect_fixtures = decorators::extract_parametrize_indirect_fixtures(decorator);
+            let indirect_fixtures =
+                decorators::extract_parametrize_indirect_fixtures(decorator, content);
             for (fixture_name, range) in indirect_fixtures {
                 let usage_line = self.get_line_from_offset(range.start().to_usize(), line_index);
                 let start_char =
@@ -453,8 +470,8 @@ impl FixtureDatabase {
                     file_path,
                     fixture_name,
                     usage_line,
-                    start_char + 1,
-                    end_char - 1,
+                    start_char,
+                    end_char,
                     false, // parametrize indirect string — not a function parameter
                 );
             }
@@ -726,13 +743,14 @@ impl FixtureDatabase {
         &self,
         value: Option<&Expr>,
         file_path: &PathBuf,
+        content: &str,
         line_index: &[usize],
     ) {
         let Some(value) = value else {
             return;
         };
 
-        let usefixtures = decorators::extract_usefixtures_from_expr(value);
+        let usefixtures = decorators::extract_usefixtures_from_expr(value, content);
         for (fixture_name, range) in usefixtures {
             let usage_line = self.get_line_from_offset(range.start().to_usize(), line_index);
             let start_char =
@@ -748,8 +766,8 @@ impl FixtureDatabase {
                 file_path,
                 fixture_name,
                 usage_line,
-                start_char.saturating_add(1),
-                end_char.saturating_sub(1),
+                start_char,
+                end_char,
                 false, // pytestmark usefixtures string — not a function parameter
             );
         }
@@ -758,7 +776,7 @@ impl FixtureDatabase {
 
 /// Python builtin types that never require an import statement.
 /// Uses O(1) `HashSet` lookup, consistent with `is_standard_library_module()`.
-static BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+static BUILTINS: std::sync::LazyLock<HashSet<&'static str>> = std::sync::LazyLock::new(|| {
     [
         "int",
         "str",
@@ -1149,133 +1167,8 @@ impl FixtureDatabase {
     /// Find the line number of the first yield statement in a function body.
     /// Returns None if no yield statement is found.
     fn find_yield_line(&self, body: &[Stmt], line_index: &[usize]) -> Option<usize> {
-        for stmt in body {
-            if let Some(line) = self.find_yield_in_stmt(stmt, line_index) {
-                return Some(line);
-            }
-        }
-        None
-    }
-
-    /// Recursively search for yield statements in a statement.
-    fn find_yield_in_stmt(&self, stmt: &Stmt, line_index: &[usize]) -> Option<usize> {
-        match stmt {
-            Stmt::Expr(expr_stmt) => self.find_yield_in_expr(&expr_stmt.value, line_index),
-            Stmt::If(if_stmt) => {
-                // Check body
-                for s in &if_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                // Check elif/else
-                for s in &if_stmt.orelse {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::With(with_stmt) => {
-                for s in &with_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::AsyncWith(with_stmt) => {
-                for s in &with_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::Try(try_stmt) => {
-                for s in &try_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                for handler in &try_stmt.handlers {
-                    let rustpython_parser::ast::ExceptHandler::ExceptHandler(h) = handler;
-                    for s in &h.body {
-                        if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                            return Some(line);
-                        }
-                    }
-                }
-                for s in &try_stmt.orelse {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                for s in &try_stmt.finalbody {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::For(for_stmt) => {
-                for s in &for_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                for s in &for_stmt.orelse {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::AsyncFor(for_stmt) => {
-                for s in &for_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                for s in &for_stmt.orelse {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            Stmt::While(while_stmt) => {
-                for s in &while_stmt.body {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                for s in &while_stmt.orelse {
-                    if let Some(line) = self.find_yield_in_stmt(s, line_index) {
-                        return Some(line);
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
-
-    /// Find yield expression and return its line number.
-    fn find_yield_in_expr(&self, expr: &Expr, line_index: &[usize]) -> Option<usize> {
-        match expr {
-            Expr::Yield(yield_expr) => {
-                let line =
-                    self.get_line_from_offset(yield_expr.range.start().to_usize(), line_index);
-                Some(line)
-            }
-            Expr::YieldFrom(yield_from) => {
-                let line =
-                    self.get_line_from_offset(yield_from.range.start().to_usize(), line_index);
-                Some(line)
-            }
-            _ => None,
-        }
+        super::docstring::find_yield_offset(body)
+            .map(|offset| self.get_line_from_offset(offset, line_index))
     }
 }
 

--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -184,10 +184,11 @@ pub fn is_parametrize_decorator(expr: &Expr) -> bool {
 /// Returns true if `name` is a plain Python identifier (the only thing a parametrize argname can
 /// legally be). Used to reject anything we couldn't cleanly locate in the source, e.g. implicitly
 /// concatenated string literals, so a rename never corrupts the file.
+/// Unicode-aware to match `is_valid_python_identifier` in the rename provider.
 fn is_plain_identifier(name: &str) -> bool {
     let mut chars = name.chars();
-    matches!(chars.next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
-        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+    matches!(chars.next(), Some(c) if c == '_' || c.is_alphabetic())
+        && chars.all(|c| c == '_' || c.is_alphanumeric())
 }
 
 /// Splits the *source text* of a string literal into argnames, each paired with the precise

--- a/src/fixtures/decorators.rs
+++ b/src/fixtures/decorators.rs
@@ -70,9 +70,59 @@ pub fn is_usefixtures_decorator(expr: &Expr) -> bool {
     is_pytest_mark_decorator(expr, "usefixtures")
 }
 
+/// Returns the range of a string literal's content, without the surrounding
+/// prefix (`r`, `b`, `u`, `f`) and quote run (`'`/`"`, single or triple).
+///
+/// `literal` is the literal's exact source text and `range` its full range;
+/// falls back to the full range when the text doesn't look like a string.
+fn literal_content_range(
+    literal: &str,
+    range: rustpython_parser::text_size::TextRange,
+) -> rustpython_parser::text_size::TextRange {
+    use rustpython_parser::text_size::{TextRange, TextSize};
+
+    let bytes = literal.as_bytes();
+    let mut prefix = 0;
+    while prefix < bytes.len()
+        && matches!(
+            bytes[prefix],
+            b'r' | b'R' | b'b' | b'B' | b'u' | b'U' | b'f' | b'F'
+        )
+    {
+        prefix += 1;
+    }
+    let Some(&quote) = bytes.get(prefix) else {
+        return range;
+    };
+    if quote != b'"' && quote != b'\'' {
+        return range;
+    }
+    let quote_len =
+        if bytes.len() >= prefix + 3 && bytes[prefix + 1] == quote && bytes[prefix + 2] == quote {
+            3
+        } else {
+            1
+        };
+
+    let content_offset = prefix + quote_len;
+    let content_end = literal.len().saturating_sub(quote_len);
+    if content_offset > content_end {
+        return range;
+    }
+    TextRange::new(
+        range.start() + TextSize::from(content_offset as u32),
+        range.start() + TextSize::from(content_end as u32),
+    )
+}
+
 /// Extracts fixture names from @pytest.mark.usefixtures("fix1", "fix2", ...) decorator.
+///
+/// Each name is paired with the range of the string literal's *content*
+/// (quotes and any string prefix excluded), so the range covers exactly the
+/// fixture name. `content` is the full source of the file the decorator is in.
 pub fn extract_usefixtures_names(
     expr: &Expr,
+    content: &str,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
     let Expr::Call(call) = expr else {
         return vec![];
@@ -86,7 +136,10 @@ pub fn extract_usefixtures_names(
         .filter_map(|arg| {
             if let Expr::Constant(c) = arg {
                 if let rustpython_parser::ast::Constant::Str(s) = &c.value {
-                    return Some((s.to_string(), c.range));
+                    let literal = content
+                        .get(c.range.start().to_usize()..c.range.end().to_usize())
+                        .unwrap_or("");
+                    return Some((s.to_string(), literal_content_range(literal, c.range)));
                 }
             }
             None
@@ -102,21 +155,22 @@ pub fn extract_usefixtures_names(
 ///   pytestmark = (pytest.mark.usefixtures("fix1"), pytest.mark.usefixtures("fix2"))
 pub fn extract_usefixtures_from_expr(
     expr: &Expr,
+    content: &str,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
     match expr {
         // Direct call: pytest.mark.usefixtures("fix1", "fix2")
-        Expr::Call(_) => extract_usefixtures_names(expr),
+        Expr::Call(_) => extract_usefixtures_names(expr, content),
         // List: [pytest.mark.usefixtures("fix1"), ...]
         Expr::List(list) => list
             .elts
             .iter()
-            .flat_map(extract_usefixtures_from_expr)
+            .flat_map(|e| extract_usefixtures_from_expr(e, content))
             .collect(),
         // Tuple: (pytest.mark.usefixtures("fix1"), ...)
         Expr::Tuple(tuple) => tuple
             .elts
             .iter()
-            .flat_map(extract_usefixtures_from_expr)
+            .flat_map(|e| extract_usefixtures_from_expr(e, content))
             .collect(),
         _ => vec![],
     }
@@ -308,72 +362,28 @@ fn collect_string_constants(elts: &[Expr]) -> std::collections::HashSet<String> 
         .collect()
 }
 
-/// Extracts fixture names from @pytest.mark.parametrize when indirect=True.
+/// Extracts fixture names from @pytest.mark.parametrize when they are marked
+/// indirect (`indirect=True` or `indirect=[names]`, keyword or positional).
+///
+/// Each name is paired with the precise range of its token inside the
+/// argnames literal (via [`extract_parametrize_argnames`]), so usages point
+/// at the parameter name itself rather than a whole string literal.
 pub fn extract_parametrize_indirect_fixtures(
     expr: &Expr,
+    content: &str,
 ) -> Vec<(String, rustpython_parser::text_size::TextRange)> {
-    let Expr::Call(call) = expr else {
-        return vec![];
-    };
-    if !is_parametrize_decorator(&call.func) {
+    let argnames = extract_parametrize_argnames(expr, content);
+    if argnames.is_empty() {
         return vec![];
     }
 
-    let indirect_value = call.keywords.iter().find_map(|kw| {
-        if kw.arg.as_ref().is_some_and(|a| a.as_str() == "indirect") {
-            Some(&kw.value)
-        } else {
-            None
-        }
-    });
+    let names: Vec<String> = argnames.iter().map(|(name, _)| name.clone()).collect();
+    let indirect = extract_parametrize_indirect_names(expr, &names);
 
-    let Some(indirect) = indirect_value else {
-        return vec![];
-    };
-
-    let Some(first_arg) = call.args.first() else {
-        return vec![];
-    };
-
-    let Expr::Constant(param_const) = first_arg else {
-        return vec![];
-    };
-
-    let rustpython_parser::ast::Constant::Str(param_str) = &param_const.value else {
-        return vec![];
-    };
-
-    let param_names: Vec<&str> = param_str.split(',').map(|s| s.trim()).collect();
-
-    match indirect {
-        Expr::Constant(c) => {
-            if matches!(c.value, rustpython_parser::ast::Constant::Bool(true)) {
-                return param_names
-                    .into_iter()
-                    .map(|name| (name.to_string(), param_const.range))
-                    .collect();
-            }
-        }
-        Expr::List(list) => {
-            return list
-                .elts
-                .iter()
-                .filter_map(|elt| {
-                    if let Expr::Constant(c) = elt {
-                        if let rustpython_parser::ast::Constant::Str(s) = &c.value {
-                            if param_names.contains(&s.as_str()) {
-                                return Some((s.to_string(), c.range));
-                            }
-                        }
-                    }
-                    None
-                })
-                .collect();
-        }
-        _ => {}
-    }
-
-    vec![]
+    argnames
+        .into_iter()
+        .filter(|(name, _)| indirect.contains(name))
+        .collect()
 }
 
 /// Extracts whether autouse=True is set on a @pytest.fixture decorator.

--- a/src/fixtures/docstring.rs
+++ b/src/fixtures/docstring.rs
@@ -260,6 +260,45 @@ mod tests {
     }
 
     #[test]
+    fn test_return_type_yield_in_except_handler_and_match() {
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    try:\n        pass\n    except ValueError:\n        yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    match 1:\n        case _:\n            yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_yield_in_return_and_augassign() {
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    return (yield 1)\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    x = 0\n    x += yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_yield_inside_async_for_and_while() {
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import AsyncGenerator\n@pytest.fixture\nasync def fx() -> AsyncGenerator[int, None]:\n    async for i in aiter():\n        yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    while True:\n        yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
     fn test_return_type_non_subscript_generator_falls_through() {
         // Plain `Generator` without subscript → falls through to expr_to_string.
         let ret = fixture_return_type(

--- a/src/fixtures/docstring.rs
+++ b/src/fixtures/docstring.rs
@@ -6,6 +6,58 @@
 use super::FixtureDatabase;
 use rustpython_parser::ast::{Expr, Stmt};
 
+/// Find the byte offset of the first `yield`/`yield from` in a function body.
+///
+/// Covers yields in expression statements, assignments (`x = yield ...`),
+/// returns, and all compound statements including `async for`/`async with`
+/// and `match`. Does not descend into nested function or lambda definitions —
+/// their yields belong to the inner function.
+pub(crate) fn find_yield_offset(body: &[Stmt]) -> Option<usize> {
+    fn in_expr(expr: &Expr) -> Option<usize> {
+        match expr {
+            Expr::Yield(y) => Some(y.range.start().to_usize()),
+            Expr::YieldFrom(y) => Some(y.range.start().to_usize()),
+            Expr::Await(a) => in_expr(&a.value),
+            Expr::NamedExpr(n) => in_expr(&n.value),
+            _ => None,
+        }
+    }
+
+    fn in_stmt(stmt: &Stmt) -> Option<usize> {
+        match stmt {
+            Stmt::Expr(s) => in_expr(&s.value),
+            Stmt::Assign(s) => in_expr(&s.value),
+            Stmt::AugAssign(s) => in_expr(&s.value),
+            Stmt::AnnAssign(s) => s.value.as_deref().and_then(in_expr),
+            Stmt::Return(s) => s.value.as_deref().and_then(in_expr),
+            Stmt::If(s) => find_yield_offset(&s.body).or_else(|| find_yield_offset(&s.orelse)),
+            Stmt::For(s) => find_yield_offset(&s.body).or_else(|| find_yield_offset(&s.orelse)),
+            Stmt::AsyncFor(s) => {
+                find_yield_offset(&s.body).or_else(|| find_yield_offset(&s.orelse))
+            }
+            Stmt::While(s) => find_yield_offset(&s.body).or_else(|| find_yield_offset(&s.orelse)),
+            Stmt::With(s) => find_yield_offset(&s.body),
+            Stmt::AsyncWith(s) => find_yield_offset(&s.body),
+            Stmt::Try(s) => find_yield_offset(&s.body)
+                .or_else(|| {
+                    s.handlers.iter().find_map(|handler| {
+                        let rustpython_parser::ast::ExceptHandler::ExceptHandler(h) = handler;
+                        find_yield_offset(&h.body)
+                    })
+                })
+                .or_else(|| find_yield_offset(&s.orelse))
+                .or_else(|| find_yield_offset(&s.finalbody)),
+            Stmt::Match(s) => s
+                .cases
+                .iter()
+                .find_map(|case| find_yield_offset(&case.body)),
+            _ => None,
+        }
+    }
+
+    body.iter().find_map(in_stmt)
+}
+
 impl FixtureDatabase {
     /// Extract docstring from a function body.
     /// The docstring is the first statement if it's a string literal.
@@ -29,59 +81,13 @@ impl FixtureDatabase {
         content: &str,
     ) -> Option<String> {
         if let Some(return_expr) = returns {
-            let has_yield = self.contains_yield(body);
-
-            if has_yield {
+            if find_yield_offset(body).is_some() {
                 return self.extract_yielded_type(return_expr, content);
             } else {
                 return Some(self.expr_to_string(return_expr, content));
             }
         }
         None
-    }
-
-    /// Check if a function body contains yield statements.
-    #[allow(clippy::only_used_in_recursion)]
-    pub(crate) fn contains_yield(&self, body: &[Stmt]) -> bool {
-        for stmt in body {
-            match stmt {
-                Stmt::Expr(expr_stmt) => {
-                    if let Expr::Yield(_) | Expr::YieldFrom(_) = &*expr_stmt.value {
-                        return true;
-                    }
-                }
-                Stmt::If(if_stmt)
-                    if self.contains_yield(&if_stmt.body)
-                        || self.contains_yield(&if_stmt.orelse) =>
-                {
-                    return true;
-                }
-                Stmt::For(for_stmt)
-                    if self.contains_yield(&for_stmt.body)
-                        || self.contains_yield(&for_stmt.orelse) =>
-                {
-                    return true;
-                }
-                Stmt::While(while_stmt)
-                    if self.contains_yield(&while_stmt.body)
-                        || self.contains_yield(&while_stmt.orelse) =>
-                {
-                    return true;
-                }
-                Stmt::With(with_stmt) if self.contains_yield(&with_stmt.body) => {
-                    return true;
-                }
-                Stmt::Try(try_stmt)
-                    if self.contains_yield(&try_stmt.body)
-                        || self.contains_yield(&try_stmt.orelse)
-                        || self.contains_yield(&try_stmt.finalbody) =>
-                {
-                    return true;
-                }
-                _ => {}
-            }
-        }
-        false
     }
 
     /// Extract the yielded type from a Generator/Iterator type annotation.
@@ -232,6 +238,25 @@ mod tests {
             "import pytest\nfrom typing import Iterator\n@pytest.fixture\ndef fx() -> Iterator[str]:\n    yield \"x\"\n",
         );
         assert_eq!(ret, Some("str".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_yield_inside_async_with() {
+        // An async fixture yielding inside `async with` is still a generator
+        // fixture — the yielded type must be extracted from the annotation.
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import AsyncGenerator\n@pytest.fixture\nasync def fx() -> AsyncGenerator[int, None]:\n    async with make_ctx() as c:\n        yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_assignment_yield() {
+        // `x = yield ...` also makes the function a generator.
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, str, None]:\n    x = yield 1\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
     }
 
     #[test]

--- a/src/fixtures/docstring.rs
+++ b/src/fixtures/docstring.rs
@@ -19,6 +19,32 @@ pub(crate) fn find_yield_offset(body: &[Stmt]) -> Option<usize> {
             Expr::YieldFrom(y) => Some(y.range.start().to_usize()),
             Expr::Await(a) => in_expr(&a.value),
             Expr::NamedExpr(n) => in_expr(&n.value),
+            // A yield may legally nest inside other expressions, e.g.
+            // `x = f((yield 1))`. Recurse into the common containers, but not
+            // into lambdas — a yield there belongs to the lambda, not to the
+            // enclosing function.
+            Expr::Call(c) => in_expr(&c.func)
+                .or_else(|| c.args.iter().find_map(in_expr))
+                .or_else(|| c.keywords.iter().find_map(|kw| in_expr(&kw.value))),
+            Expr::BinOp(e) => in_expr(&e.left).or_else(|| in_expr(&e.right)),
+            Expr::UnaryOp(e) => in_expr(&e.operand),
+            Expr::BoolOp(e) => e.values.iter().find_map(in_expr),
+            Expr::Compare(e) => in_expr(&e.left).or_else(|| e.comparators.iter().find_map(in_expr)),
+            Expr::IfExp(e) => in_expr(&e.test)
+                .or_else(|| in_expr(&e.body))
+                .or_else(|| in_expr(&e.orelse)),
+            Expr::Tuple(e) => e.elts.iter().find_map(in_expr),
+            Expr::List(e) => e.elts.iter().find_map(in_expr),
+            Expr::Set(e) => e.elts.iter().find_map(in_expr),
+            Expr::Dict(e) => e
+                .keys
+                .iter()
+                .flatten()
+                .find_map(in_expr)
+                .or_else(|| e.values.iter().find_map(in_expr)),
+            Expr::Subscript(e) => in_expr(&e.value).or_else(|| in_expr(&e.slice)),
+            Expr::Starred(e) => in_expr(&e.value),
+            Expr::Attribute(e) => in_expr(&e.value),
             _ => None,
         }
     }
@@ -283,6 +309,32 @@ mod tests {
             "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    x = 0\n    x += yield 1\n",
         );
         assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_yield_nested_in_expressions() {
+        // A yield nested inside a call argument still makes the function a
+        // generator.
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    x = f((yield 1))\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+
+        // ... and inside a tuple / boolean expression.
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    x = ((yield 1), 2)\n",
+        );
+        assert_eq!(ret, Some("int".to_string()));
+    }
+
+    #[test]
+    fn test_return_type_yield_in_lambda_is_not_a_generator() {
+        // A yield inside a lambda belongs to the lambda, not the fixture:
+        // the fixture is NOT a generator, so the annotation is kept whole.
+        let ret = fixture_return_type(
+            "import pytest\nfrom typing import Generator\n@pytest.fixture\ndef fx() -> Generator[int, None, None]:\n    x = lambda: (yield 1)\n    return x\n",
+        );
+        assert_eq!(ret, Some("Generator[int, None, None]".to_string()));
     }
 
     #[test]

--- a/src/fixtures/import_analysis.rs
+++ b/src/fixtures/import_analysis.rs
@@ -149,6 +149,10 @@ pub struct ImportLayout {
     pub source: ParseSource,
     /// Owned copy of each file line for `TextEdit` character-length lookups.
     lines: Vec<String>,
+    /// Whether the file ends with a newline. Used to decide if a TextEdit may
+    /// end at column 0 of the line after the last one (valid only when the
+    /// trailing newline exists).
+    pub has_trailing_newline: bool,
 }
 
 impl ImportLayout {
@@ -166,12 +170,20 @@ impl ImportLayout {
             bare_imports,
             source,
             lines,
+            has_trailing_newline: content.ends_with('\n'),
         }
     }
 
     /// Borrow all lines as `&str` slices (for passing to sort/insert helpers).
     pub fn line_strs(&self) -> Vec<&str> {
         self.lines.iter().map(|s| s.as_str()).collect()
+    }
+
+    /// Whether a position at column 0 of `line + 1` is still inside the
+    /// document (a following line exists, or the trailing newline makes the
+    /// virtual line after the last one addressable).
+    pub fn next_line_exists(&self, line: usize) -> bool {
+        line + 1 < self.lines.len() || self.has_trailing_newline
     }
 
     /// Find a module-level `from <module> import …` entry that is *not* a

--- a/src/fixtures/import_analysis.rs
+++ b/src/fixtures/import_analysis.rs
@@ -174,11 +174,6 @@ impl ImportLayout {
         self.lines.iter().map(|s| s.as_str()).collect()
     }
 
-    /// Get a single 0-based line as `&str` (empty string if out of bounds).
-    pub fn line(&self, idx: usize) -> &str {
-        self.lines.get(idx).map(|s| s.as_str()).unwrap_or("")
-    }
-
     /// Find a module-level `from <module> import …` entry that is *not* a
     /// star-import, regardless of whether it is single-line or multiline.
     ///

--- a/src/fixtures/imports.rs
+++ b/src/fixtures/imports.rs
@@ -9,7 +9,6 @@
 
 use super::types::TypeImportSpec;
 use super::FixtureDatabase;
-use once_cell::sync::Lazy;
 use rustpython_parser::ast::{Expr, Stmt};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -31,92 +30,93 @@ static RUNTIME_STDLIB_MODULES: OnceLock<HashSet<String>> = OnceLock::new();
 /// Intentionally conservative — it is better to misclassify an unknown
 /// third-party module as stdlib (and skip inserting a redundant import)
 /// than to misclassify a stdlib module as third-party.
-static STDLIB_MODULES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    [
-        "os",
-        "sys",
-        "re",
-        "json",
-        "typing",
-        "collections",
-        "functools",
-        "itertools",
-        "pathlib",
-        "datetime",
-        "time",
-        "math",
-        "random",
-        "copy",
-        "io",
-        "abc",
-        "contextlib",
-        "dataclasses",
-        "enum",
-        "logging",
-        "unittest",
-        "asyncio",
-        "concurrent",
-        "multiprocessing",
-        "threading",
-        "subprocess",
-        "shutil",
-        "tempfile",
-        "glob",
-        "fnmatch",
-        "pickle",
-        "sqlite3",
-        "urllib",
-        "http",
-        "email",
-        "html",
-        "xml",
-        "socket",
-        "ssl",
-        "select",
-        "signal",
-        "struct",
-        "codecs",
-        "textwrap",
-        "string",
-        "difflib",
-        "inspect",
-        "dis",
-        "traceback",
-        "warnings",
-        "weakref",
-        "types",
-        "importlib",
-        "pkgutil",
-        "pprint",
-        "reprlib",
-        "numbers",
-        "decimal",
-        "fractions",
-        "statistics",
-        "hashlib",
-        "hmac",
-        "secrets",
-        "base64",
-        "binascii",
-        "zlib",
-        "gzip",
-        "bz2",
-        "lzma",
-        "zipfile",
-        "tarfile",
-        "csv",
-        "configparser",
-        "argparse",
-        "getopt",
-        "getpass",
-        "platform",
-        "errno",
-        "ctypes",
-        "__future__",
-    ]
-    .into_iter()
-    .collect()
-});
+static STDLIB_MODULES: std::sync::LazyLock<HashSet<&'static str>> =
+    std::sync::LazyLock::new(|| {
+        [
+            "os",
+            "sys",
+            "re",
+            "json",
+            "typing",
+            "collections",
+            "functools",
+            "itertools",
+            "pathlib",
+            "datetime",
+            "time",
+            "math",
+            "random",
+            "copy",
+            "io",
+            "abc",
+            "contextlib",
+            "dataclasses",
+            "enum",
+            "logging",
+            "unittest",
+            "asyncio",
+            "concurrent",
+            "multiprocessing",
+            "threading",
+            "subprocess",
+            "shutil",
+            "tempfile",
+            "glob",
+            "fnmatch",
+            "pickle",
+            "sqlite3",
+            "urllib",
+            "http",
+            "email",
+            "html",
+            "xml",
+            "socket",
+            "ssl",
+            "select",
+            "signal",
+            "struct",
+            "codecs",
+            "textwrap",
+            "string",
+            "difflib",
+            "inspect",
+            "dis",
+            "traceback",
+            "warnings",
+            "weakref",
+            "types",
+            "importlib",
+            "pkgutil",
+            "pprint",
+            "reprlib",
+            "numbers",
+            "decimal",
+            "fractions",
+            "statistics",
+            "hashlib",
+            "hmac",
+            "secrets",
+            "base64",
+            "binascii",
+            "zlib",
+            "gzip",
+            "bz2",
+            "lzma",
+            "zipfile",
+            "tarfile",
+            "csv",
+            "configparser",
+            "argparse",
+            "getopt",
+            "getpass",
+            "platform",
+            "errno",
+            "ctypes",
+            "__future__",
+        ]
+        .into_iter()
+        .collect()
+    });
 
 /// Represents a fixture import in a Python file.
 #[derive(Debug, Clone)]
@@ -424,24 +424,24 @@ impl FixtureDatabase {
     /// This handles `from .module import *` patterns that bring fixtures into scope.
     ///
     /// Results are cached with content-hash and definitions-version based invalidation.
-    /// Returns fixture names that are available in `file_path` via imports.
+    /// Returns a map from fixture name to the file its import resolves to.
     pub fn get_imported_fixtures(
         &self,
         file_path: &Path,
         visited: &mut HashSet<PathBuf>,
-    ) -> HashSet<String> {
+    ) -> HashMap<String, PathBuf> {
         let canonical_path = self.get_canonical_path(file_path.to_path_buf());
 
         // Prevent circular imports
         if visited.contains(&canonical_path) {
             debug!("Circular import detected for {:?}, skipping", file_path);
-            return HashSet::new();
+            return HashMap::new();
         }
         visited.insert(canonical_path.clone());
 
         // Get the file content first (needed for cache validation)
         let Some(content) = self.get_file_content(&canonical_path) else {
-            return HashSet::new();
+            return HashMap::new();
         };
 
         let content_hash = Self::hash_content(&content);
@@ -487,8 +487,8 @@ impl FixtureDatabase {
         canonical_path: &Path,
         content: &str,
         visited: &mut HashSet<PathBuf>,
-    ) -> HashSet<String> {
-        let mut imported_fixtures = HashSet::new();
+    ) -> HashMap<String, PathBuf> {
+        let mut imported_fixtures = HashMap::new();
 
         let Some(parsed) = self.get_parsed_ast(canonical_path, content) else {
             return imported_fixtures;
@@ -523,18 +523,22 @@ impl FixtureDatabase {
                     // First, get fixtures defined directly in that file
                     if let Some(file_fixtures) = self.file_definitions.get(&resolved_canonical) {
                         for fixture_name in file_fixtures.iter() {
-                            imported_fixtures.insert(fixture_name.clone());
+                            imported_fixtures
+                                .insert(fixture_name.clone(), resolved_canonical.clone());
                         }
                     }
 
-                    // Also recursively get fixtures imported into that file
+                    // Also recursively get fixtures imported into that file.
+                    // Direct imports win over transitive ones on name clashes.
                     let transitive = self.get_imported_fixtures(&resolved_canonical, visited);
-                    imported_fixtures.extend(transitive);
+                    for (name, source) in transitive {
+                        imported_fixtures.entry(name).or_insert(source);
+                    }
                 } else {
                     // Explicit import: only include the specified names if they are fixtures
                     for name in &import.imported_names {
                         if self.definitions.contains_key(name) {
-                            imported_fixtures.insert(name.clone());
+                            imported_fixtures.insert(name.clone(), resolved_canonical.clone());
                         }
                     }
                 }
@@ -561,24 +565,18 @@ impl FixtureDatabase {
 
                 if let Some(file_fixtures) = self.file_definitions.get(&resolved_canonical) {
                     for fixture_name in file_fixtures.iter() {
-                        imported_fixtures.insert(fixture_name.clone());
+                        imported_fixtures.insert(fixture_name.clone(), resolved_canonical.clone());
                     }
                 }
 
                 let transitive = self.get_imported_fixtures(&resolved_canonical, visited);
-                imported_fixtures.extend(transitive);
+                for (name, source) in transitive {
+                    imported_fixtures.entry(name).or_insert(source);
+                }
             }
         }
 
         imported_fixtures
-    }
-
-    /// Check if a fixture is available in a file via imports.
-    /// This is used in resolution to check conftest.py files that import fixtures.
-    pub fn is_fixture_imported_in_file(&self, fixture_name: &str, file_path: &Path) -> bool {
-        let mut visited = HashSet::new();
-        let imported = self.get_imported_fixtures(file_path, &mut visited);
-        imported.contains(fixture_name)
     }
 }
 

--- a/src/fixtures/imports.rs
+++ b/src/fixtures/imports.rs
@@ -545,7 +545,14 @@ impl FixtureDatabase {
                         .get(&resolved_canonical)
                         .map(|entry| entry.value().clone())
                         .unwrap_or_default();
-                    let reexported = self.get_imported_fixtures(&resolved_canonical, visited);
+                    // Recurse with a clone of `visited`: it must still guard the
+                    // current path against cycles, but marking the module as
+                    // globally visited here would make a later import of the
+                    // same module (e.g. a subsequent star import) hit the
+                    // circular guard and silently lose its transitive fixtures.
+                    let mut nested_visited = visited.clone();
+                    let reexported =
+                        self.get_imported_fixtures(&resolved_canonical, &mut nested_visited);
 
                     for name in &import.imported_names {
                         if module_fixtures.contains(name) {

--- a/src/fixtures/imports.rs
+++ b/src/fixtures/imports.rs
@@ -535,9 +535,24 @@ impl FixtureDatabase {
                         imported_fixtures.entry(name).or_insert(source);
                     }
                 } else {
-                    // Explicit import: only include the specified names if they are fixtures
+                    // Explicit import: prefer names actually defined in the
+                    // resolved module, then names it re-exports (transitively,
+                    // attributed to their true source). Fall back to any known
+                    // fixture name so modules that were resolved but never
+                    // scanned don't lose their fixtures.
+                    let module_fixtures: HashSet<String> = self
+                        .file_definitions
+                        .get(&resolved_canonical)
+                        .map(|entry| entry.value().clone())
+                        .unwrap_or_default();
+                    let reexported = self.get_imported_fixtures(&resolved_canonical, visited);
+
                     for name in &import.imported_names {
-                        if self.definitions.contains_key(name) {
+                        if module_fixtures.contains(name) {
+                            imported_fixtures.insert(name.clone(), resolved_canonical.clone());
+                        } else if let Some(source) = reexported.get(name) {
+                            imported_fixtures.insert(name.clone(), source.clone());
+                        } else if self.definitions.contains_key(name) {
                             imported_fixtures.insert(name.clone(), resolved_canonical.clone());
                         }
                     }

--- a/src/fixtures/mod.rs
+++ b/src/fixtures/mod.rs
@@ -42,6 +42,11 @@ pub struct EditableInstall {
     pub site_packages: PathBuf,
 }
 
+/// Cache entry for the identity-keyed line index: (content Arc identity, line_index).
+/// A hit requires upgrading the Weak and comparing Arc pointers, which makes
+/// it ABA-safe (a freed-and-reused allocation can't produce a false hit).
+type LineIndexIdentityCacheEntry = (std::sync::Weak<String>, Arc<Vec<usize>>);
+
 /// Cache entry for line indices: (content_hash, line_index).
 /// The content hash is used to invalidate the cache when file content changes.
 type LineIndexCacheEntry = (u64, Arc<Vec<usize>>);
@@ -111,6 +116,9 @@ pub struct FixtureDatabase {
     /// Cache of line indices (byte offsets) for files to avoid recomputation.
     /// Stores (content_hash, line_index) to invalidate when content changes.
     pub line_index_cache: Arc<DashMap<PathBuf, LineIndexCacheEntry>>,
+    /// Identity-keyed line-index cache so repeated per-column position
+    /// conversions skip re-hashing the whole file.
+    pub line_index_by_identity: Arc<DashMap<PathBuf, LineIndexIdentityCacheEntry>>,
     /// Cache of parsed AST for files to avoid re-parsing.
     /// Stores (content_hash, ast) to invalidate when content changes.
     pub ast_cache: Arc<DashMap<PathBuf, AstCacheEntry>>,
@@ -164,6 +172,7 @@ impl FixtureDatabase {
             imports: Arc::new(DashMap::new()),
             canonical_path_cache: Arc::new(DashMap::new()),
             line_index_cache: Arc::new(DashMap::new()),
+            line_index_by_identity: Arc::new(DashMap::new()),
             ast_cache: Arc::new(DashMap::new()),
             definitions_version: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             cycle_cache: Arc::new(DashMap::new()),
@@ -211,10 +220,16 @@ impl FixtureDatabase {
         if let Some(cached) = self.file_cache.get(file_path) {
             return Some(Arc::clone(cached.value()));
         }
+
+        // or_insert (not insert): if an analyze_file with fresher editor-buffer
+        // content raced in between the miss above and here, keep that buffer
+        // instead of clobbering it with our possibly-stale disk read.
         let content = Arc::new(std::fs::read_to_string(file_path).ok()?);
-        self.file_cache
-            .insert(file_path.to_path_buf(), Arc::clone(&content));
-        Some(content)
+        let entry = self
+            .file_cache
+            .entry(file_path.to_path_buf())
+            .or_insert(content);
+        Some(Arc::clone(entry.value()))
     }
 
     /// Get or compute line index for a file, with content-hash-based caching.
@@ -242,6 +257,32 @@ impl FixtureDatabase {
         );
 
         arc_index
+    }
+
+    /// Get the line index for a content `Arc`, skipping the O(file) content
+    /// hash when the same `Arc` was seen last. Used by per-column position
+    /// conversions, which can run hundreds of times per request.
+    pub(crate) fn get_line_index_for(
+        &self,
+        file_path: &Path,
+        content: &Arc<String>,
+    ) -> Arc<Vec<usize>> {
+        if let Some(entry) = self.line_index_by_identity.get(file_path) {
+            let (weak, index) = entry.value();
+            if weak
+                .upgrade()
+                .is_some_and(|cached| Arc::ptr_eq(&cached, content))
+            {
+                return Arc::clone(index);
+            }
+        }
+
+        let index = self.get_line_index(file_path, content);
+        self.line_index_by_identity.insert(
+            file_path.to_path_buf(),
+            (Arc::downgrade(content), Arc::clone(&index)),
+        );
+        index
     }
 
     /// Get or parse AST for a file, with content-hash-based caching.
@@ -359,6 +400,7 @@ impl FixtureDatabase {
 
         // Remove from line_index_cache
         self.line_index_cache.remove(&canonical);
+        self.line_index_by_identity.remove(&canonical);
 
         // Remove from ast_cache
         self.ast_cache.remove(&canonical);
@@ -420,6 +462,7 @@ impl FixtureDatabase {
                 self.file_cache.remove(&path);
                 // Also clean related caches for consistency
                 self.line_index_cache.remove(&path);
+                self.line_index_by_identity.remove(&path);
                 self.ast_cache.remove(&path);
                 self.available_fixtures_cache.remove(&path);
                 self.imported_fixtures_cache.remove(&path);

--- a/src/fixtures/mod.rs
+++ b/src/fixtures/mod.rs
@@ -58,9 +58,10 @@ type CycleCacheEntry = (u64, Arc<Vec<types::FixtureCycle>>);
 /// The version is incremented when definitions change to invalidate the cache.
 type AvailableFixturesCacheEntry = (u64, Arc<Vec<FixtureDefinition>>);
 
-/// Cache entry for imported fixtures: (content_hash, definitions_version, imported_fixture_names).
+/// Cache entry for imported fixtures: (content_hash, definitions_version,
+/// imported fixture name → file the import resolves to).
 /// Invalidated when either the file content or fixture definitions change.
-type ImportedFixturesCacheEntry = (u64, u64, Arc<HashSet<String>>);
+type ImportedFixturesCacheEntry = (u64, u64, Arc<HashMap<String, PathBuf>>);
 
 /// Cache entry for the name→TypeImportSpec map: (content_hash, Arc<map>).
 /// Invalidated when the file content changes (same strategy as ast_cache).
@@ -80,7 +81,8 @@ type NameImportMapCacheEntry = (
 );
 
 /// Maximum number of files to keep in the file content cache.
-/// When exceeded, the oldest entries are evicted to prevent unbounded memory growth.
+/// When exceeded, a batch of entries (in arbitrary map order — not LRU) is
+/// evicted to prevent unbounded memory growth.
 const MAX_FILE_CACHE_SIZE: usize = 2000;
 
 /// The central database for fixture definitions and usages.
@@ -202,13 +204,17 @@ impl FixtureDatabase {
     }
 
     /// Get file content from cache or read from filesystem.
+    /// Disk reads are cached so repeated requests for scanned (non-open)
+    /// files don't hit the filesystem every time.
     /// Returns None if file cannot be read.
     pub(crate) fn get_file_content(&self, file_path: &Path) -> Option<Arc<String>> {
         if let Some(cached) = self.file_cache.get(file_path) {
-            Some(Arc::clone(cached.value()))
-        } else {
-            std::fs::read_to_string(file_path).ok().map(Arc::new)
+            return Some(Arc::clone(cached.value()));
         }
+        let content = Arc::new(std::fs::read_to_string(file_path).ok()?);
+        self.file_cache
+            .insert(file_path.to_path_buf(), Arc::clone(&content));
+        Some(content)
     }
 
     /// Get or compute line index for a file, with content-hash-based caching.
@@ -383,7 +389,15 @@ impl FixtureDatabase {
     /// Called periodically to prevent unbounded memory growth in very large workspaces.
     /// Most LSPs rely on did_close cleanup for open files; this is a safety net for
     /// workspace scan files that accumulate over time.
-    pub(crate) fn evict_cache_if_needed(&self) {
+    ///
+    /// Only derived, recomputable caches are evicted; `definitions`/`usages` are
+    /// the index itself and are never evicted here.
+    ///
+    /// `keep` is the file currently being analyzed — it is never evicted, since
+    /// its caches were just populated and are about to be used.
+    // ponytail: eviction picks arbitrary entries (DashMap iteration order), not
+    // LRU — add access-time tracking if churn ever shows up in profiles.
+    pub(crate) fn evict_cache_if_needed(&self, keep: &Path) {
         // Only evict if significantly over limit to avoid frequent eviction
         if self.file_cache.len() > MAX_FILE_CACHE_SIZE {
             debug!(
@@ -397,6 +411,7 @@ impl FixtureDatabase {
             let to_remove: Vec<PathBuf> = self
                 .file_cache
                 .iter()
+                .filter(|entry| entry.key() != keep)
                 .take(to_remove_count)
                 .map(|entry| entry.key().clone())
                 .collect();

--- a/src/fixtures/resolver.rs
+++ b/src/fixtures/resolver.rs
@@ -11,7 +11,7 @@ use super::types::{
 use super::FixtureDatabase;
 use rustpython_parser::ast::{Arguments, Expr, Ranged, Stmt};
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 impl FixtureDatabase {
@@ -75,16 +75,20 @@ impl FixtureDatabase {
         None
     }
 
-    /// Get the fixture definition at a specific line (if the line is a fixture definition)
+    /// Get the fixture definition at a specific line (if the line is a fixture definition).
+    /// Uses the file_definitions reverse index instead of scanning all definitions.
     fn get_fixture_definition_at_line(
         &self,
         file_path: &Path,
         line: usize,
     ) -> Option<FixtureDefinition> {
-        for entry in self.definitions.iter() {
-            for def in entry.value().iter() {
-                if def.file_path == file_path && def.line == line {
-                    return Some(def.clone());
+        let names = self.file_definitions.get(file_path)?;
+        for name in names.iter() {
+            if let Some(defs) = self.definitions.get(name) {
+                for def in defs.iter() {
+                    if def.file_path == file_path && def.line == line {
+                        return Some(def.clone());
+                    }
                 }
             }
         }
@@ -228,22 +232,30 @@ impl FixtureDatabase {
             // Then check if the conftest imports this fixture
             // Check both filesystem and file cache for conftest existence
             let conftest_in_cache = self.file_cache.contains_key(&conftest_path);
-            if (conftest_path.exists() || conftest_in_cache)
-                && self.is_fixture_imported_in_file(fixture_name, &conftest_path)
-            {
-                // The fixture is imported in this conftest, so it's available here
-                // Return the original definition (pytest makes it available at conftest scope)
-                debug!(
-                    "Fixture {} is imported in conftest.py: {:?}",
-                    fixture_name, conftest_path
-                );
-                // Get any matching definition that passes the filter
-                if let Some(def) = definitions.iter().find(|def| filter(def)) {
-                    info!(
-                        "Found imported fixture {} via conftest.py: {:?} (original: {:?})",
-                        fixture_name, conftest_path, def.file_path
+            if conftest_path.exists() || conftest_in_cache {
+                let mut visited = HashSet::new();
+                let imported = self.get_imported_fixtures(&conftest_path, &mut visited);
+                if let Some(source) = imported.get(fixture_name) {
+                    // The fixture is imported in this conftest, so it's available here
+                    // Return the original definition (pytest makes it available at
+                    // conftest scope). Prefer the definition from the file the import
+                    // actually resolves to; fall back to any matching definition when
+                    // the source file's definition isn't indexed.
+                    debug!(
+                        "Fixture {} is imported in conftest.py: {:?} (from {:?})",
+                        fixture_name, conftest_path, source
                     );
-                    return Some(def.clone());
+                    if let Some(def) = definitions
+                        .iter()
+                        .find(|def| &def.file_path == source && filter(def))
+                        .or_else(|| definitions.iter().find(|def| filter(def)))
+                    {
+                        info!(
+                            "Found imported fixture {} via conftest.py: {:?} (original: {:?})",
+                            fixture_name, conftest_path, def.file_path
+                        );
+                        return Some(def.clone());
+                    }
                 }
             }
 
@@ -356,26 +368,22 @@ impl FixtureDatabase {
         super::string_utils::extract_word_at_position(line, character)
     }
 
-    /// Find all references (usages) of a fixture by name
+    /// Find all references (usages) of a fixture by name.
+    /// Uses the usage_by_fixture reverse index instead of scanning all usages.
     pub fn find_fixture_references(&self, fixture_name: &str) -> Vec<FixtureUsage> {
         info!("Finding all references for fixture: {}", fixture_name);
 
-        let mut all_references = Vec::new();
-
-        for entry in self.usages.iter() {
-            let file_path = entry.key();
-            let usages = entry.value();
-
-            for usage in usages.iter() {
-                if usage.name == fixture_name {
-                    debug!(
-                        "Found reference to {} in {:?} at line {}",
-                        fixture_name, file_path, usage.line
-                    );
-                    all_references.push(usage.clone());
-                }
-            }
-        }
+        let all_references: Vec<FixtureUsage> = self
+            .usage_by_fixture
+            .get(fixture_name)
+            .map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|(_, usage)| usage.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
 
         info!(
             "Found {} total references for fixture: {}",
@@ -399,11 +407,18 @@ impl FixtureDatabase {
 
         let mut matching_references = Vec::new();
 
-        // Use reverse index for O(m) lookup instead of O(n) iteration over all usages
-        let Some(usages_for_fixture) = self.usage_by_fixture.get(&definition.name) else {
-            info!("No references found for fixture: {}", definition.name);
-            return matching_references;
-        };
+        // Use reverse index for O(m) lookup instead of O(n) iteration over all usages.
+        // Snapshot the bucket so the shard guard is not held across the resolution
+        // calls below (they take guards on other maps; holding this one blocks
+        // writers to the bucket and is a latent deadlock hazard).
+        let usages_for_fixture: Vec<(PathBuf, FixtureUsage)> =
+            match self.usage_by_fixture.get(&definition.name) {
+                Some(entry) => entry.value().clone(),
+                None => {
+                    info!("No references found for fixture: {}", definition.name);
+                    return matching_references;
+                }
+            };
 
         for (file_path, usage) in usages_for_fixture.iter() {
             let fixture_def_at_line = self.get_fixture_definition_at_line(file_path, usage.line);
@@ -459,8 +474,11 @@ impl FixtureDatabase {
 
     /// Get all available fixtures for a given file.
     /// Results are cached with version-based invalidation for performance.
-    /// Returns Arc to avoid cloning the potentially large Vec on cache hits.
-    pub fn get_available_fixtures(&self, file_path: &Path) -> Vec<FixtureDefinition> {
+    /// Returns Arc so cache hits are an O(1) refcount bump, not a Vec clone.
+    pub fn get_available_fixtures(
+        &self,
+        file_path: &Path,
+    ) -> std::sync::Arc<Vec<FixtureDefinition>> {
         use std::sync::Arc;
 
         // Canonicalize path for consistent cache keys
@@ -474,107 +492,104 @@ impl FixtureDatabase {
         if let Some(cached) = self.available_fixtures_cache.get(&file_path) {
             let (cached_version, cached_fixtures) = cached.value();
             if *cached_version == current_version {
-                // Return cloned Vec from Arc (cheap reference count increment)
-                return cached_fixtures.as_ref().clone();
+                return Arc::clone(cached_fixtures);
             }
         }
 
         // Compute available fixtures
-        let available_fixtures = self.compute_available_fixtures(&file_path);
+        let available_fixtures = Arc::new(self.compute_available_fixtures(&file_path));
 
         // Store in cache
         self.available_fixtures_cache.insert(
             file_path,
-            (current_version, Arc::new(available_fixtures.clone())),
+            (current_version, Arc::clone(&available_fixtures)),
         );
 
         available_fixtures
     }
 
     /// Internal method to compute available fixtures without caching.
+    ///
+    /// Single pass over all definitions: each definition gets a rank encoding
+    /// pytest's priority rules (same file < closest conftest < plugin <
+    /// third-party), and the lowest-ranked definition wins per fixture name.
+    /// This is O(total_defs + ancestor_dirs) instead of scanning the whole
+    /// definitions map once per ancestor directory.
     fn compute_available_fixtures(&self, file_path: &Path) -> Vec<FixtureDefinition> {
-        let mut available_fixtures = Vec::new();
-        let mut seen_names = HashSet::new();
+        use std::collections::HashMap;
 
-        // Priority 1: Fixtures in the same file
-        for entry in self.definitions.iter() {
-            let fixture_name = entry.key();
-            for def in entry.value().iter() {
-                if def.file_path == file_path && !seen_names.contains(fixture_name.as_str()) {
-                    available_fixtures.push(def.clone());
-                    seen_names.insert(fixture_name.clone());
-                }
-            }
+        // Rank ancestor conftests by proximity. Ranks are doubled so that
+        // fixtures *imported into* a conftest slot in just after the ones
+        // defined directly in it (rank * 2 + 1).
+        let mut conftest_rank: HashMap<PathBuf, usize> = HashMap::new();
+        let mut ancestor_conftests: Vec<PathBuf> = Vec::new();
+        let mut depth = 1usize;
+        let mut dir = file_path.parent();
+        while let Some(d) = dir {
+            let conftest_path = d.join("conftest.py");
+            conftest_rank.insert(conftest_path.clone(), depth * 2);
+            ancestor_conftests.push(conftest_path);
+            depth += 1;
+            dir = d.parent();
         }
+        let plugin_rank = depth * 2;
+        let third_party_rank = depth * 2 + 2;
 
-        // Priority 2: Fixtures in conftest.py files (including imported fixtures)
-        if let Some(mut current_dir) = file_path.parent() {
-            loop {
-                let conftest_path = current_dir.join("conftest.py");
-
-                // First add fixtures defined directly in the conftest
-                for entry in self.definitions.iter() {
-                    let fixture_name = entry.key();
-                    for def in entry.value().iter() {
-                        if def.file_path == conftest_path
-                            && !seen_names.contains(fixture_name.as_str())
-                        {
-                            available_fixtures.push(def.clone());
-                            seen_names.insert(fixture_name.clone());
-                        }
+        let mut best: HashMap<String, (usize, FixtureDefinition)> = HashMap::new();
+        let mut consider =
+            |name: &str, rank: usize, def: &FixtureDefinition| match best.get_mut(name) {
+                Some(existing) => {
+                    if rank < existing.0 {
+                        *existing = (rank, def.clone());
                     }
                 }
+                None => {
+                    best.insert(name.to_string(), (rank, def.clone()));
+                }
+            };
 
-                // Then add fixtures imported into the conftest
-                if self.file_cache.contains_key(&conftest_path) {
-                    let mut visited = HashSet::new();
-                    let imported_fixtures =
-                        self.get_imported_fixtures(&conftest_path, &mut visited);
-                    for fixture_name in imported_fixtures {
-                        if !seen_names.contains(&fixture_name) {
-                            // Get the original definition for this imported fixture
-                            if let Some(definitions) = self.definitions.get(&fixture_name) {
-                                if let Some(def) = definitions.first() {
-                                    available_fixtures.push(def.clone());
-                                    seen_names.insert(fixture_name);
-                                }
-                            }
-                        }
+        for entry in self.definitions.iter() {
+            let fixture_name = entry.key();
+            for def in entry.value().iter() {
+                let rank = if def.file_path == file_path {
+                    0
+                } else if let Some(rank) = conftest_rank.get(&def.file_path) {
+                    *rank
+                } else if def.is_third_party {
+                    third_party_rank
+                } else if def.is_plugin {
+                    plugin_rank
+                } else {
+                    // Not visible from this file (e.g. another test file).
+                    continue;
+                };
+                consider(fixture_name, rank, def);
+            }
+        }
+
+        // Fixtures imported into ancestor conftests (results are cached per conftest).
+        for conftest_path in &ancestor_conftests {
+            if !self.file_cache.contains_key(conftest_path) {
+                continue;
+            }
+            let rank = conftest_rank[conftest_path] + 1;
+            let mut visited = HashSet::new();
+            for (fixture_name, source) in self.get_imported_fixtures(conftest_path, &mut visited) {
+                // Prefer the definition from the file the import resolves to.
+                if let Some(definitions) = self.definitions.get(&fixture_name) {
+                    if let Some(def) = definitions
+                        .iter()
+                        .find(|def| def.file_path == source)
+                        .or_else(|| definitions.first())
+                    {
+                        consider(&fixture_name, rank, def);
                     }
                 }
-
-                match current_dir.parent() {
-                    Some(parent) => current_dir = parent,
-                    None => break,
-                }
             }
         }
 
-        // Priority 3: Plugin fixtures (pytest11 entry points, e.g. workspace editable installs)
-        for entry in self.definitions.iter() {
-            let fixture_name = entry.key();
-            for def in entry.value().iter() {
-                if def.is_plugin
-                    && !def.is_third_party
-                    && !seen_names.contains(fixture_name.as_str())
-                {
-                    available_fixtures.push(def.clone());
-                    seen_names.insert(fixture_name.clone());
-                }
-            }
-        }
-
-        // Priority 4: Third-party fixtures from site-packages
-        for entry in self.definitions.iter() {
-            let fixture_name = entry.key();
-            for def in entry.value().iter() {
-                if def.is_third_party && !seen_names.contains(fixture_name.as_str()) {
-                    available_fixtures.push(def.clone());
-                    seen_names.insert(fixture_name.clone());
-                }
-            }
-        }
-
+        let mut available_fixtures: Vec<FixtureDefinition> =
+            best.into_values().map(|(_, def)| def).collect();
         available_fixtures.sort_by(|a, b| a.name.cmp(&b.name));
         available_fixtures
     }

--- a/src/fixtures/string_utils.rs
+++ b/src/fixtures/string_utils.rs
@@ -66,49 +66,46 @@ pub(crate) fn format_docstring(docstring: String) -> String {
     result.join("\n")
 }
 
-/// Extract the word at a given character position in a line.
+/// Extract the word at a given byte offset in a line.
 /// Returns None if the position is not within a word.
-pub(crate) fn extract_word_at_position(line: &str, character: usize) -> Option<String> {
-    let char_indices: Vec<(usize, char)> = line.char_indices().collect();
-
-    if character >= char_indices.len() {
+///
+/// The offset is interpreted in bytes to match the columns stored in
+/// `FixtureUsage`/`FixtureDefinition`; offsets inside a multi-byte character
+/// are floored to its start.
+pub(crate) fn extract_word_at_position(line: &str, byte_col: usize) -> Option<String> {
+    if byte_col >= line.len() {
         return None;
     }
 
-    let (_byte_pos, c) = char_indices[character];
+    // Floor to the containing character's boundary.
+    let mut idx = byte_col;
+    while !line.is_char_boundary(idx) {
+        idx -= 1;
+    }
 
-    if !c.is_alphanumeric() && c != '_' {
+    let is_word = |c: char| c.is_alphanumeric() || c == '_';
+    if !line[idx..].chars().next().is_some_and(is_word) {
         return None;
     }
 
-    // Find start of word
-    let mut start_idx = character;
-    while start_idx > 0 {
-        let (_, prev_c) = char_indices[start_idx - 1];
-        if !prev_c.is_alphanumeric() && prev_c != '_' {
-            break;
-        }
-        start_idx -= 1;
-    }
+    // Scan backwards for the start of the word.
+    let start = line[..idx]
+        .char_indices()
+        .rev()
+        .take_while(|(_, c)| is_word(*c))
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(idx);
 
-    // Find end of word
-    let mut end_idx = character + 1;
-    while end_idx < char_indices.len() {
-        let (_, curr_c) = char_indices[end_idx];
-        if !curr_c.is_alphanumeric() && curr_c != '_' {
-            break;
-        }
-        end_idx += 1;
-    }
+    // Scan forwards for the end of the word.
+    let end = line[idx..]
+        .char_indices()
+        .take_while(|(_, c)| is_word(*c))
+        .last()
+        .map(|(i, c)| idx + i + c.len_utf8())
+        .unwrap_or(idx);
 
-    let start_byte = char_indices[start_idx].0;
-    let end_byte = if end_idx < char_indices.len() {
-        char_indices[end_idx].0
-    } else {
-        line.len()
-    };
-
-    Some(line[start_byte..end_byte].to_string())
+    Some(line[start..end].to_string())
 }
 
 /// Find the character position of a function name in a line of code.
@@ -262,6 +259,29 @@ mod tests {
         );
         assert_eq!(extract_word_at_position(line, 16), Some("arg1".to_string()));
         assert_eq!(extract_word_at_position(line, 20), None); // comma
+    }
+
+    #[test]
+    fn test_extract_word_at_position_non_ascii() {
+        // "é" is two bytes — offsets are bytes, not chars.
+        let line = "def test(café_fixture):";
+        assert_eq!(
+            extract_word_at_position(line, 10),
+            Some("café_fixture".to_string())
+        );
+        // Offset inside the multi-byte "é" floors to the character start.
+        assert_eq!(
+            extract_word_at_position(line, 14),
+            Some("café_fixture".to_string())
+        );
+        // Word after a non-ASCII prefix resolves at its byte offset.
+        let line = "x = 'é'; fixture_a";
+        assert_eq!(
+            extract_word_at_position(line, 10),
+            Some("fixture_a".to_string())
+        );
+        // Past end of line.
+        assert_eq!(extract_word_at_position(line, 100), None);
     }
 
     #[test]

--- a/src/fixtures/undeclared.rs
+++ b/src/fixtures/undeclared.rs
@@ -754,18 +754,20 @@ mod tests {
     #[test]
     fn test_walrus_targets_collected_through_containers() {
         // Walrus bindings nested in calls, comparisons, boolean/unary/binary
-        // ops, tuples and ternaries all register as locals.
+        // ops, tuples and ternaries all register as locals. The target shadows
+        // a known fixture name so the test fails if collection stops working
+        // (an uncollected `my_fixture` read would be flagged as undeclared).
         for body in [
-            "    x = f((v := 1))\n    _ = v\n",
-            "    x = (v := 1) < 2\n    _ = v\n",
-            "    x = not (v := 1)\n    _ = v\n",
-            "    x = (v := 1) + 1\n    _ = v\n",
-            "    x = ((v := 1), 2)\n    _ = v\n",
-            "    x = 1 if (v := 2) else (w := 3)\n    _ = v\n",
+            "    x = f((my_fixture := 1))\n    _ = my_fixture\n",
+            "    x = (my_fixture := 1) < 2\n    _ = my_fixture\n",
+            "    x = not (my_fixture := 1)\n    _ = my_fixture\n",
+            "    x = (my_fixture := 1) + 1\n    _ = my_fixture\n",
+            "    x = ((my_fixture := 1), 2)\n    _ = my_fixture\n",
+            "    x = 1 if (my_fixture := 2) else 3\n    _ = my_fixture\n",
         ] {
             let undeclared = analyze_with_conftest(body);
             assert!(
-                undeclared.iter().all(|u| u.name != "v" && u.name != "w"),
+                undeclared.iter().all(|u| u.name != "my_fixture"),
                 "walrus target should be a local in {body:?}, got {undeclared:?}"
             );
         }

--- a/src/fixtures/undeclared.rs
+++ b/src/fixtures/undeclared.rs
@@ -47,7 +47,13 @@ fn collect_walrus_targets(expr: &Expr, names: &mut HashSet<String>) {
                 .iter()
                 .for_each(|c| collect_walrus_targets(c, names));
         }
-        Expr::Call(e) => e.args.iter().for_each(|a| collect_walrus_targets(a, names)),
+        Expr::Call(e) => {
+            collect_walrus_targets(&e.func, names);
+            e.args.iter().for_each(|a| collect_walrus_targets(a, names));
+            e.keywords
+                .iter()
+                .for_each(|kw| collect_walrus_targets(&kw.value, names));
+        }
         Expr::Tuple(e) => e.elts.iter().for_each(|v| collect_walrus_targets(v, names)),
         Expr::IfExp(e) => {
             collect_walrus_targets(&e.test, names);
@@ -759,6 +765,7 @@ mod tests {
         // (an uncollected `my_fixture` read would be flagged as undeclared).
         for body in [
             "    x = f((my_fixture := 1))\n    _ = my_fixture\n",
+            "    x = f(kw=(my_fixture := 1))\n    _ = my_fixture\n",
             "    x = (my_fixture := 1) < 2\n    _ = my_fixture\n",
             "    x = not (my_fixture := 1)\n    _ = my_fixture\n",
             "    x = (my_fixture := 1) + 1\n    _ = my_fixture\n",

--- a/src/fixtures/undeclared.rs
+++ b/src/fixtures/undeclared.rs
@@ -21,6 +21,43 @@ pub(crate) struct BodyScanContext<'a> {
     pub function_line: usize,
 }
 
+/// Collect names bound by walrus (`:=`) expressions anywhere inside `expr`.
+fn collect_walrus_targets(expr: &Expr, names: &mut HashSet<String>) {
+    if let Expr::NamedExpr(named) = expr {
+        if let Expr::Name(name) = named.target.as_ref() {
+            names.insert(name.id.to_string());
+        }
+        collect_walrus_targets(&named.value, names);
+        return;
+    }
+    // Recurse into the common containers a walrus realistically appears in.
+    match expr {
+        Expr::BoolOp(e) => e
+            .values
+            .iter()
+            .for_each(|v| collect_walrus_targets(v, names)),
+        Expr::BinOp(e) => {
+            collect_walrus_targets(&e.left, names);
+            collect_walrus_targets(&e.right, names);
+        }
+        Expr::UnaryOp(e) => collect_walrus_targets(&e.operand, names),
+        Expr::Compare(e) => {
+            collect_walrus_targets(&e.left, names);
+            e.comparators
+                .iter()
+                .for_each(|c| collect_walrus_targets(c, names));
+        }
+        Expr::Call(e) => e.args.iter().for_each(|a| collect_walrus_targets(a, names)),
+        Expr::Tuple(e) => e.elts.iter().for_each(|v| collect_walrus_targets(v, names)),
+        Expr::IfExp(e) => {
+            collect_walrus_targets(&e.test, names);
+            collect_walrus_targets(&e.body, names);
+            collect_walrus_targets(&e.orelse, names);
+        }
+        _ => {}
+    }
+}
+
 impl FixtureDatabase {
     /// Scan a function body for undeclared fixture usages.
     /// An undeclared fixture is a reference to a fixture that exists in the database
@@ -78,6 +115,7 @@ impl FixtureDatabase {
                     for target in &assign.targets {
                         self.collect_names_from_expr(target, &mut temp_names);
                     }
+                    collect_walrus_targets(&assign.value, &mut temp_names);
                     for name in temp_names {
                         local_vars.insert(name, line);
                     }
@@ -121,9 +159,23 @@ impl FixtureDatabase {
                     self.collect_local_variables(&for_stmt.body, line_index, local_vars);
                 }
                 Stmt::While(while_stmt) => {
+                    let line =
+                        self.get_line_from_offset(while_stmt.range.start().to_usize(), line_index);
+                    let mut temp_names = HashSet::new();
+                    collect_walrus_targets(&while_stmt.test, &mut temp_names);
+                    for name in temp_names {
+                        local_vars.insert(name, line);
+                    }
                     self.collect_local_variables(&while_stmt.body, line_index, local_vars);
                 }
                 Stmt::If(if_stmt) => {
+                    let line =
+                        self.get_line_from_offset(if_stmt.range.start().to_usize(), line_index);
+                    let mut temp_names = HashSet::new();
+                    collect_walrus_targets(&if_stmt.test, &mut temp_names);
+                    for name in temp_names {
+                        local_vars.insert(name, line);
+                    }
                     self.collect_local_variables(&if_stmt.body, line_index, local_vars);
                     self.collect_local_variables(&if_stmt.orelse, line_index, local_vars);
                 }
@@ -196,10 +248,16 @@ impl FixtureDatabase {
                 for stmt in &while_stmt.body {
                     self.visit_stmt_for_names(stmt, ctx);
                 }
+                for stmt in &while_stmt.orelse {
+                    self.visit_stmt_for_names(stmt, ctx);
+                }
             }
             Stmt::For(for_stmt) => {
                 self.visit_expr_for_names(&for_stmt.iter, ctx);
                 for stmt in &for_stmt.body {
+                    self.visit_stmt_for_names(stmt, ctx);
+                }
+                for stmt in &for_stmt.orelse {
                     self.visit_stmt_for_names(stmt, ctx);
                 }
             }
@@ -229,6 +287,47 @@ impl FixtureDatabase {
                 self.visit_expr_for_names(&assert_stmt.test, ctx);
                 if let Some(ref msg) = assert_stmt.msg {
                     self.visit_expr_for_names(msg, ctx);
+                }
+            }
+            Stmt::AnnAssign(ann_assign) => {
+                if let Some(ref value) = ann_assign.value {
+                    self.visit_expr_for_names(value, ctx);
+                }
+            }
+            Stmt::Raise(raise_stmt) => {
+                if let Some(ref exc) = raise_stmt.exc {
+                    self.visit_expr_for_names(exc, ctx);
+                }
+                if let Some(ref cause) = raise_stmt.cause {
+                    self.visit_expr_for_names(cause, ctx);
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                for stmt in &try_stmt.body {
+                    self.visit_stmt_for_names(stmt, ctx);
+                }
+                for handler in &try_stmt.handlers {
+                    let rustpython_parser::ast::ExceptHandler::ExceptHandler(h) = handler;
+                    for stmt in &h.body {
+                        self.visit_stmt_for_names(stmt, ctx);
+                    }
+                }
+                for stmt in &try_stmt.orelse {
+                    self.visit_stmt_for_names(stmt, ctx);
+                }
+                for stmt in &try_stmt.finalbody {
+                    self.visit_stmt_for_names(stmt, ctx);
+                }
+            }
+            Stmt::Match(match_stmt) => {
+                self.visit_expr_for_names(&match_stmt.subject, ctx);
+                for case in &match_stmt.cases {
+                    if let Some(ref guard) = case.guard {
+                        self.visit_expr_for_names(guard, ctx);
+                    }
+                    for stmt in &case.body {
+                        self.visit_stmt_for_names(stmt, ctx);
+                    }
                 }
             }
             _ => {}
@@ -327,6 +426,67 @@ impl FixtureDatabase {
             }
             Expr::Await(await_expr) => {
                 self.visit_expr_for_names(&await_expr.value, ctx);
+            }
+            Expr::BoolOp(bool_op) => {
+                for value in &bool_op.values {
+                    self.visit_expr_for_names(value, ctx);
+                }
+            }
+            Expr::IfExp(if_exp) => {
+                self.visit_expr_for_names(&if_exp.test, ctx);
+                self.visit_expr_for_names(&if_exp.body, ctx);
+                self.visit_expr_for_names(&if_exp.orelse, ctx);
+            }
+            Expr::NamedExpr(named) => {
+                // Only the value is a read; the walrus target is a binding.
+                self.visit_expr_for_names(&named.value, ctx);
+            }
+            Expr::Starred(starred) => {
+                self.visit_expr_for_names(&starred.value, ctx);
+            }
+            Expr::JoinedStr(joined) => {
+                for value in &joined.values {
+                    self.visit_expr_for_names(value, ctx);
+                }
+            }
+            Expr::FormattedValue(formatted) => {
+                self.visit_expr_for_names(&formatted.value, ctx);
+            }
+            Expr::Set(set) => {
+                for elt in &set.elts {
+                    self.visit_expr_for_names(elt, ctx);
+                }
+            }
+            Expr::Slice(slice) => {
+                for part in [&slice.lower, &slice.upper, &slice.step]
+                    .into_iter()
+                    .flatten()
+                {
+                    self.visit_expr_for_names(part, ctx);
+                }
+            }
+            // Comprehensions: only the iterables are visited — elements and
+            // conditions typically reference comprehension-local loop targets,
+            // which would produce false positives without scope tracking.
+            Expr::ListComp(comp) => {
+                for generator in &comp.generators {
+                    self.visit_expr_for_names(&generator.iter, ctx);
+                }
+            }
+            Expr::SetComp(comp) => {
+                for generator in &comp.generators {
+                    self.visit_expr_for_names(&generator.iter, ctx);
+                }
+            }
+            Expr::GeneratorExp(comp) => {
+                for generator in &comp.generators {
+                    self.visit_expr_for_names(&generator.iter, ctx);
+                }
+            }
+            Expr::DictComp(comp) => {
+                for generator in &comp.generators {
+                    self.visit_expr_for_names(&generator.iter, ctx);
+                }
             }
             _ => {}
         }
@@ -487,6 +647,58 @@ mod tests {
         assert!(
             undeclared.iter().all(|u| u.name != "my_fixture"),
             "declared parameter should suppress flag, got {:?}",
+            undeclared
+        );
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_fstring() {
+        let undeclared = analyze_with_conftest("    x = f\"{my_fixture}\"\n");
+        assert!(
+            undeclared.iter().any(|u| u.name == "my_fixture"),
+            "fixture inside f-string should be flagged, got {:?}",
+            undeclared
+        );
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_ternary_and_boolop() {
+        let undeclared = analyze_with_conftest("    x = 1 if my_fixture else 2\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest("    x = my_fixture or None\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_ann_assign_and_raise() {
+        let undeclared = analyze_with_conftest("    x: int = my_fixture\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest("    raise ValueError(my_fixture)\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_try_and_comprehension_iterable() {
+        let undeclared = analyze_with_conftest(
+            "    try:\n        _ = my_fixture\n    except KeyError:\n        pass\n",
+        );
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest("    x = [i for i in my_fixture]\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_walrus_target_not_flagged() {
+        // `(my_fixture := 5)` binds a local; neither the binding nor a later
+        // read of it should be flagged as an undeclared fixture.
+        let undeclared =
+            analyze_with_conftest("    if (my_fixture := 5):\n        _ = my_fixture\n");
+        assert!(
+            undeclared.iter().all(|u| u.name != "my_fixture"),
+            "walrus binding should suppress undeclared flag, got {:?}",
             undeclared
         );
     }

--- a/src/fixtures/undeclared.rs
+++ b/src/fixtures/undeclared.rs
@@ -704,6 +704,74 @@ mod tests {
     }
 
     #[test]
+    fn test_undeclared_flagged_in_match_and_orelse_blocks() {
+        let undeclared =
+            analyze_with_conftest("    match my_fixture:\n        case _:\n            pass\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared =
+            analyze_with_conftest("    match 1:\n        case _:\n            _ = my_fixture\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest(
+            "    for i in []:\n        pass\n    else:\n        _ = my_fixture\n",
+        );
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest(
+            "    while False:\n        pass\n    else:\n        _ = my_fixture\n",
+        );
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_raise_from_and_finally() {
+        let undeclared = analyze_with_conftest("    raise ValueError() from my_fixture\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared =
+            analyze_with_conftest("    try:\n        pass\n    finally:\n        _ = my_fixture\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest(
+            "    try:\n        pass\n    except ValueError:\n        pass\n    else:\n        _ = my_fixture\n",
+        );
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_undeclared_flagged_in_set_slice_and_starred() {
+        let undeclared = analyze_with_conftest("    x = {my_fixture}\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest("    x = [1, 2][my_fixture:]\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+
+        let undeclared = analyze_with_conftest("    x = [*my_fixture]\n");
+        assert!(undeclared.iter().any(|u| u.name == "my_fixture"));
+    }
+
+    #[test]
+    fn test_walrus_targets_collected_through_containers() {
+        // Walrus bindings nested in calls, comparisons, boolean/unary/binary
+        // ops, tuples and ternaries all register as locals.
+        for body in [
+            "    x = f((v := 1))\n    _ = v\n",
+            "    x = (v := 1) < 2\n    _ = v\n",
+            "    x = not (v := 1)\n    _ = v\n",
+            "    x = (v := 1) + 1\n    _ = v\n",
+            "    x = ((v := 1), 2)\n    _ = v\n",
+            "    x = 1 if (v := 2) else (w := 3)\n    _ = v\n",
+        ] {
+            let undeclared = analyze_with_conftest(body);
+            assert!(
+                undeclared.iter().all(|u| u.name != "v" && u.name != "w"),
+                "walrus target should be a local in {body:?}, got {undeclared:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_is_available_fixture_same_file() {
         let db = FixtureDatabase::new();
         let conftest_path = PathBuf::from("/tmp/pls_avail/conftest.py");

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,10 +174,15 @@ fn handle_fixtures_unused(path: PathBuf, format: &str) {
                 })
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&json_output).unwrap_or_else(|_| "[]".to_string())
-        );
+        match serde_json::to_string_pretty(&json_output) {
+            Ok(json) => println!("{}", json),
+            Err(e) => {
+                // Don't emit "[]" here — that would read as "no unused
+                // fixtures" to CI consumers even though some were found.
+                eprintln!("error: failed to serialize output as JSON: {}", e);
+                std::process::exit(1);
+            }
+        }
     } else {
         println!(
             "{} {} unused fixture(s):\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,10 @@ fn handle_fixtures_unused(path: PathBuf, format: &str) {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json_output).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_output).unwrap_or_else(|_| "[]".to_string())
+        );
     } else {
         println!(
             "{} {} unused fixture(s):\n",

--- a/src/providers/call_hierarchy.rs
+++ b/src/providers/call_hierarchy.rs
@@ -27,10 +27,11 @@ impl Backend {
 
         if let Some(file_path) = self.uri_to_path(&uri) {
             // Find the fixture at the cursor position (works on both definitions and usages)
+            let byte_col = self.to_byte_col(&file_path, position);
             if let Some(definition) = self.fixture_db.find_fixture_or_definition_at_position(
                 &file_path,
                 position.line,
-                position.character,
+                byte_col,
             ) {
                 let Some(def_uri) = self.path_to_uri(&definition.file_path) else {
                     return Ok(None);
@@ -40,11 +41,19 @@ impl Backend {
                 let selection_range = Range {
                     start: Position {
                         line: def_line,
-                        character: definition.start_char as u32,
+                        character: self.to_lsp_col(
+                            &definition.file_path,
+                            definition.line,
+                            definition.start_char,
+                        ),
                     },
                     end: Position {
                         line: def_line,
-                        character: definition.end_char as u32,
+                        character: self.to_lsp_col(
+                            &definition.file_path,
+                            definition.line,
+                            definition.end_char,
+                        ),
                     },
                 };
 
@@ -120,11 +129,11 @@ impl Backend {
             let from_range = Range {
                 start: Position {
                     line: usage_line,
-                    character: usage.start_char as u32,
+                    character: self.to_lsp_col(&usage.file_path, usage.line, usage.start_char),
                 },
                 end: Position {
                     line: usage_line,
-                    character: usage.end_char as u32,
+                    character: self.to_lsp_col(&usage.file_path, usage.line, usage.end_char),
                 },
             };
 
@@ -196,11 +205,19 @@ impl Backend {
                 let to_range = Range {
                     start: Position {
                         line: dep_line,
-                        character: dep_def.start_char as u32,
+                        character: self.to_lsp_col(
+                            &dep_def.file_path,
+                            dep_def.line,
+                            dep_def.start_char,
+                        ),
                     },
                     end: Position {
                         line: dep_line,
-                        character: dep_def.end_char as u32,
+                        character: self.to_lsp_col(
+                            &dep_def.file_path,
+                            dep_def.line,
+                            dep_def.end_char,
+                        ),
                     },
                 };
 
@@ -258,11 +275,11 @@ impl Backend {
             let range = Range {
                 start: Position {
                     line: lsp_line,
-                    character: start as u32,
+                    character: self.to_lsp_col(file_path, line, start),
                 },
                 end: Position {
                     line: lsp_line,
-                    character: (start + param_name.len()) as u32,
+                    character: self.to_lsp_col(file_path, line, start + param_name.len()),
                 },
             };
             return Some(vec![range]);

--- a/src/providers/code_action.rs
+++ b/src/providers/code_action.rs
@@ -132,18 +132,36 @@ fn emit_kind_import_edits(
                 // multiline — for single-line fi.line == fi.end_line).
                 // The range ends at column 0 of the following line (replacing the
                 // trailing newline) so no column-encoding conversion is needed.
+                // When the import is the last line of a file with no trailing
+                // newline, that position would fall outside the document (some
+                // clients reject such edits), so end at the line's clamped end
+                // instead (the spec clamps an oversized character to line length).
+                let (end, new_text) = if layout.next_line_exists(fi.end_line) {
+                    (
+                        Position {
+                            line: fi.end_line as u32 + 1,
+                            character: 0,
+                        },
+                        format!("{}\n", merged_line),
+                    )
+                } else {
+                    (
+                        Position {
+                            line: fi.end_line as u32,
+                            character: u32::MAX,
+                        },
+                        merged_line.clone(),
+                    )
+                };
                 edits.push(TextEdit {
                     range: Range {
                         start: Position {
                             line: fi.line as u32,
                             character: 0,
                         },
-                        end: Position {
-                            line: fi.end_line as u32 + 1,
-                            character: 0,
-                        },
+                        end,
                     },
-                    new_text: format!("{}\n", merged_line),
+                    new_text,
                 });
             } else {
                 // Cannot merge (string-fallback multiline without names) → insert new line.
@@ -1049,6 +1067,44 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_build_import_edits_merge_into_final_line_without_trailing_newline() {
+        // The import is the last line and the file has no trailing newline:
+        // ending the range at (end_line + 1, 0) would fall outside the
+        // document, so the edit must end on the import line itself.
+        let layout = parse_import_layout("from typing import Optional");
+        let spec = TypeImportSpec {
+            check_name: "Any".to_string(),
+            import_statement: "from typing import Any".to_string(),
+        };
+        let existing: HashSet<String> = HashSet::new();
+        let edits = build_import_edits(&layout, &[&spec], &existing);
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.start.line, 0);
+        assert_eq!(edits[0].range.end.line, 0);
+        assert_eq!(edits[0].range.end.character, u32::MAX);
+        assert_eq!(edits[0].new_text, "from typing import Any, Optional");
+    }
+
+    #[test]
+    fn test_build_import_edits_merge_into_final_line_with_trailing_newline() {
+        // Same layout but the file ends with a newline: the (end_line + 1, 0)
+        // position is addressable, so the whole-line replacement stays.
+        let layout = parse_import_layout("from typing import Optional\n");
+        let spec = TypeImportSpec {
+            check_name: "Any".to_string(),
+            import_statement: "from typing import Any".to_string(),
+        };
+        let existing: HashSet<String> = HashSet::new();
+        let edits = build_import_edits(&layout, &[&spec], &existing);
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.end.line, 1);
+        assert_eq!(edits[0].range.end.character, 0);
+        assert_eq!(edits[0].new_text, "from typing import Any, Optional\n");
     }
 
     #[test]

--- a/src/providers/code_action.rs
+++ b/src/providers/code_action.rs
@@ -148,7 +148,10 @@ fn emit_kind_import_edits(
                     (
                         Position {
                             line: fi.end_line as u32,
-                            character: u32::MAX,
+                            // LSP uinteger max (2^31 - 1): past any real line
+                            // length, so clients clamp to end-of-line, and it
+                            // fits the signed 32-bit ints JVM clients use.
+                            character: i32::MAX as u32,
                         },
                         merged_line.clone(),
                     )
@@ -1085,7 +1088,7 @@ mod tests {
         assert_eq!(edits.len(), 1);
         assert_eq!(edits[0].range.start.line, 0);
         assert_eq!(edits[0].range.end.line, 0);
-        assert_eq!(edits[0].range.end.character, u32::MAX);
+        assert_eq!(edits[0].range.end.character, i32::MAX as u32);
         assert_eq!(edits[0].new_text, "from typing import Any, Optional");
     }
 

--- a/src/providers/code_action.rs
+++ b/src/providers/code_action.rs
@@ -130,7 +130,8 @@ fn emit_kind_import_edits(
 
                 // Cover all lines of the import (same range for single-line and
                 // multiline — for single-line fi.line == fi.end_line).
-                let end_char = layout.line(fi.end_line).len() as u32;
+                // The range ends at column 0 of the following line (replacing the
+                // trailing newline) so no column-encoding conversion is needed.
                 edits.push(TextEdit {
                     range: Range {
                         start: Position {
@@ -138,11 +139,11 @@ fn emit_kind_import_edits(
                             character: 0,
                         },
                         end: Position {
-                            line: fi.end_line as u32,
-                            character: end_char,
+                            line: fi.end_line as u32 + 1,
+                            character: 0,
                         },
                     },
-                    new_text: merged_line,
+                    new_text: format!("{}\n", merged_line),
                 });
             } else {
                 // Cannot merge (string-fallback multiline without names) → insert new line.
@@ -463,7 +464,7 @@ impl Backend {
                 }
 
                 let diag_line = Self::lsp_line_to_internal(diagnostic.range.start.line);
-                let diag_char = diagnostic.range.start.character as usize;
+                let diag_char = self.to_byte_col(&file_path, diagnostic.range.start) as usize;
 
                 info!(
                     "Looking for undeclared fixture at line={}, char={}",
@@ -516,7 +517,7 @@ impl Backend {
                 };
 
                 let insert_line = Self::internal_line_to_lsp(insertion.line);
-                let insert_char = insertion.char_pos as u32;
+                let insert_char = self.to_lsp_col(&file_path, insertion.line, insertion.char_pos);
 
                 let param_text = match &insertion.multiline_indent {
                     Some(indent) => {
@@ -573,7 +574,7 @@ impl Backend {
                     diagnostics: Some(vec![diagnostic.clone()]),
                     edit: Some(edit),
                     command: None,
-                    is_preferred: Some(true),
+                    is_preferred: Some(actions.is_empty()),
                     disabled: None,
                     data: None,
                 };
@@ -621,7 +622,7 @@ impl Backend {
                                 continue;
                             }
 
-                            let cursor_char = range.start.character as usize;
+                            let cursor_char = self.to_byte_col(&file_path, range.start) as usize;
                             if cursor_char < usage.start_char || cursor_char > usage.end_char {
                                 continue;
                             }
@@ -657,8 +658,9 @@ impl Backend {
                                 build_import_edits(&layout, &spec_refs, &existing_imports);
 
                             let lsp_line = Self::internal_line_to_lsp(usage.line);
+                            let lsp_col = self.to_lsp_col(&file_path, usage.line, usage.end_char);
                             all_edits.push(TextEdit {
-                                range: Self::create_point_range(lsp_line, usage.end_char as u32),
+                                range: Self::create_point_range(lsp_line, lsp_col),
                                 new_text: format!(": {}", adapted_type),
                             });
 
@@ -679,7 +681,7 @@ impl Backend {
                                 diagnostics: None,
                                 edit: Some(ws_edit),
                                 command: None,
-                                is_preferred: Some(true),
+                                is_preferred: Some(actions.is_empty()),
                                 disabled: None,
                                 data: None,
                             };
@@ -733,8 +735,9 @@ impl Backend {
 
                             // Annotation edit.
                             let lsp_line = Self::internal_line_to_lsp(usage.line);
+                            let lsp_col = self.to_lsp_col(&file_path, usage.line, usage.end_char);
                             annotation_edits.push(TextEdit {
-                                range: Self::create_point_range(lsp_line, usage.end_char as u32),
+                                range: Self::create_point_range(lsp_line, lsp_col),
                                 new_text: format!(": {}", adapted_type),
                             });
 
@@ -881,8 +884,9 @@ mod tests {
         assert_eq!(edits.len(), 1);
         assert_eq!(edits[0].range.start.line, 1);
         assert_eq!(edits[0].range.start.character, 0);
-        assert_eq!(edits[0].range.end.line, 1);
-        assert_eq!(edits[0].new_text, "from typing import Any, Optional");
+        assert_eq!(edits[0].range.end.line, 2);
+        assert_eq!(edits[0].range.end.character, 0);
+        assert_eq!(edits[0].new_text, "from typing import Any, Optional\n");
     }
 
     #[test]
@@ -914,7 +918,10 @@ mod tests {
         let existing: HashSet<String> = HashSet::new();
         let edits = build_import_edits(&layout, &[&spec1, &spec2], &existing);
         assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "from typing import Any, Optional, Union");
+        assert_eq!(
+            edits[0].new_text,
+            "from typing import Any, Optional, Union\n"
+        );
     }
 
     #[test]
@@ -928,7 +935,10 @@ mod tests {
         let existing: HashSet<String> = HashSet::new();
         let edits = build_import_edits(&layout, &[&spec], &existing);
         assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "from pathlib import Path as P, PurePath");
+        assert_eq!(
+            edits[0].new_text,
+            "from pathlib import Path as P, PurePath\n"
+        );
     }
 
     #[test]
@@ -966,7 +976,7 @@ mod tests {
         assert_eq!(edits.len(), 1);
         assert_eq!(
             edits[0].new_text,
-            "from os import getcwd, othermodule, path"
+            "from os import getcwd, othermodule, path\n"
         );
     }
 
@@ -985,7 +995,7 @@ mod tests {
         let existing: HashSet<String> = HashSet::new();
         let edits = build_import_edits(&layout, &[&spec], &existing);
         assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "from typing import Any, Optional");
+        assert_eq!(edits[0].new_text, "from typing import Any, Optional\n");
         assert!(
             !edits[0].new_text.contains('#'),
             "merged line must not contain the original comment"
@@ -1016,8 +1026,70 @@ mod tests {
         assert_eq!(edits.len(), 1);
         assert_eq!(edits[0].range.start.line, 0);
         assert_eq!(edits[0].range.start.character, 0);
-        assert_eq!(edits[0].range.end.line, 3);
-        assert_eq!(edits[0].new_text, "from typing import Any, Optional, Union");
+        assert_eq!(edits[0].range.end.line, 4);
+        assert_eq!(edits[0].range.end.character, 0);
+        assert_eq!(
+            edits[0].new_text,
+            "from typing import Any, Optional, Union\n"
+        );
+    }
+
+    /// Assert that no two edits in the set overlap (LSP forbids overlapping
+    /// TextEdits within a single TextDocumentEdit).
+    fn assert_no_overlaps(edits: &[TextEdit]) {
+        let key = |p: &Position| (p.line, p.character);
+        for (i, a) in edits.iter().enumerate() {
+            for b in edits.iter().skip(i + 1) {
+                let disjoint = key(&a.range.end) <= key(&b.range.start)
+                    || key(&b.range.end) <= key(&a.range.start);
+                assert!(
+                    disjoint,
+                    "overlapping edits: {:?} and {:?}",
+                    a.range, b.range
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_import_edits_merge_plus_insert_do_not_overlap() {
+        // A multiline merge (block replace) combined with new imports that sort
+        // before and after the block in the same group must not produce
+        // overlapping TextEdits.
+        let lines = vec![
+            "from typing import (",
+            "    Any,",
+            "    Optional,",
+            ")",
+            "",
+            "def test(): pass",
+        ];
+        let layout = layout_from_lines(&lines);
+        let merge_spec = TypeImportSpec {
+            check_name: "Union".to_string(),
+            import_statement: "from typing import Union".to_string(),
+        };
+        let before_spec = TypeImportSpec {
+            check_name: "ABC".to_string(),
+            import_statement: "from abc import ABC".to_string(),
+        };
+        let after_spec = TypeImportSpec {
+            check_name: "getcwd".to_string(),
+            import_statement: "from os import getcwd".to_string(),
+        };
+        let existing: HashSet<String> = HashSet::new();
+        let edits = build_import_edits(
+            &layout,
+            &[&merge_spec, &before_spec, &after_spec],
+            &existing,
+        );
+
+        assert!(
+            edits.len() >= 2,
+            "expected merge + inserts, got {:?}",
+            edits
+        );
+        assert_no_overlaps(&edits);
     }
 
     // adapt tests live in src/fixtures/import_analysis.rs

--- a/src/providers/code_lens.rs
+++ b/src/providers/code_lens.rs
@@ -18,16 +18,34 @@ impl Backend {
             return Ok(None);
         };
 
-        // Get all definitions in this file
+        // Get all definitions in this file using the file_definitions reverse
+        // index (avoids scanning the whole workspace).
         let mut lenses = Vec::new();
 
-        for entry in self.fixture_db.definitions.iter() {
-            for def in entry.value() {
-                // Only show lenses for fixtures defined in this file
-                if def.file_path != file_path || def.is_third_party {
-                    continue;
-                }
+        let fixture_names: Vec<String> = self
+            .fixture_db
+            .file_definitions
+            .get(&file_path)
+            .map(|entry| entry.value().iter().cloned().collect())
+            .unwrap_or_default();
 
+        for name in &fixture_names {
+            // Snapshot matching definitions so no map guard is held across the
+            // find_references_for_definition call below (it reads this map too).
+            let defs: Vec<_> = self
+                .fixture_db
+                .definitions
+                .get(name)
+                .map(|entry| {
+                    entry
+                        .value()
+                        .iter()
+                        .filter(|def| def.file_path == file_path && !def.is_third_party)
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+            for def in &defs {
                 // Count usages for this definition
                 let references = self.fixture_db.find_references_for_definition(def);
                 let usage_count = references.len();
@@ -46,7 +64,7 @@ impl Backend {
                 let arguments = match (
                     serde_json::to_value(uri.to_string()),
                     serde_json::to_value(line),
-                    serde_json::to_value(def.start_char),
+                    serde_json::to_value(self.to_lsp_col(&def.file_path, def.line, def.start_char)),
                 ) {
                     (Ok(uri_val), Ok(line_val), Ok(char_val)) => {
                         Some(vec![uri_val, line_val, char_val])

--- a/src/providers/completion.rs
+++ b/src/providers/completion.rs
@@ -129,20 +129,20 @@ struct EnrichedFixture {
 /// Filter available fixtures according to common rules and enrich them with
 /// detail/sort metadata.
 fn filter_and_enrich_fixtures(
-    available: Vec<FixtureDefinition>,
+    available: &[FixtureDefinition],
     file_path: &std::path::Path,
     declared_params: Option<&[String]>,
     opts: &CompletionOpts<'_>,
 ) -> Vec<EnrichedFixture> {
     available
-        .into_iter()
+        .iter()
         .filter(|f| !is_fixture_excluded(f, declared_params, opts))
         .map(|f| {
-            let detail = make_fixture_detail(&f);
-            let priority = fixture_sort_priority(&f, file_path);
+            let detail = make_fixture_detail(f);
+            let priority = fixture_sort_priority(f, file_path);
             let sort_text = make_sort_text(priority, &f.name);
             EnrichedFixture {
-                fixture: f,
+                fixture: f.clone(),
                 detail,
                 sort_text,
             }
@@ -175,11 +175,11 @@ impl Backend {
 
         if let Some(file_path) = self.uri_to_path(&uri) {
             // Get the completion context
-            if let Some(ctx) = self.fixture_db.get_completion_context(
-                &file_path,
-                position.line,
-                position.character,
-            ) {
+            let byte_col = self.to_byte_col(&file_path, position);
+            if let Some(ctx) =
+                self.fixture_db
+                    .get_completion_context(&file_path, position.line, byte_col)
+            {
                 info!("Completion context: {:?}", ctx);
 
                 // Get workspace root for formatting documentation
@@ -266,7 +266,7 @@ impl Backend {
     ) -> CompletionResponse {
         let available = self.fixture_db.get_available_fixtures(file_path);
         let enriched =
-            filter_and_enrich_fixtures(available, file_path, Some(declared_params), opts);
+            filter_and_enrich_fixtures(&available, file_path, Some(declared_params), opts);
 
         let items = enriched
             .into_iter()
@@ -304,7 +304,7 @@ impl Backend {
     ) -> CompletionResponse {
         let available = self.fixture_db.get_available_fixtures(file_path);
         let enriched =
-            filter_and_enrich_fixtures(available, file_path, Some(declared_params), opts);
+            filter_and_enrich_fixtures(&available, file_path, Some(declared_params), opts);
 
         // Get insertion info for adding new parameters
         let insertion_info = self
@@ -342,8 +342,9 @@ impl Backend {
                         }
                     };
                     let lsp_line = Self::internal_line_to_lsp(info.line);
+                    let lsp_col = self.to_lsp_col(file_path, info.line, info.char_pos);
                     vec![TextEdit {
-                        range: Self::create_point_range(lsp_line, info.char_pos as u32),
+                        range: Self::create_point_range(lsp_line, lsp_col),
                         new_text: text,
                     }]
                 });
@@ -380,7 +381,7 @@ impl Backend {
             current_fixture_name: None,
             insert_prefix,
         };
-        let enriched = filter_and_enrich_fixtures(available, file_path, None, &no_filter_opts);
+        let enriched = filter_and_enrich_fixtures(&available, file_path, None, &no_filter_opts);
 
         let items = enriched
             .into_iter()
@@ -612,7 +613,7 @@ mod tests {
             current_fixture_name: Some("my_fixture"),
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures.clone(), file, None, &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, file, None, &opts);
         assert_eq!(enriched.len(), 1);
         assert_eq!(enriched[0].fixture.name, "other_fixture");
 
@@ -622,7 +623,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures, file, None, &test_opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, file, None, &test_opts);
         assert_eq!(enriched.len(), 2);
     }
 
@@ -642,7 +643,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures.clone(), &file_path, Some(&[]), &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, Some(&[]), &opts);
         let names: Vec<&str> = enriched.iter().map(|e| e.fixture.name.as_str()).collect();
         assert_eq!(names, vec!["session_fix"]);
 
@@ -652,7 +653,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures.clone(), &file_path, Some(&[]), &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, Some(&[]), &opts);
         let names: Vec<&str> = enriched.iter().map(|e| e.fixture.name.as_str()).collect();
         assert_eq!(names, vec!["module_fix", "session_fix"]);
 
@@ -662,7 +663,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures.clone(), &file_path, Some(&[]), &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, Some(&[]), &opts);
         assert_eq!(enriched.len(), 4);
 
         // Test function context (None scope): all should survive
@@ -671,7 +672,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures.clone(), &file_path, Some(&[]), &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, Some(&[]), &opts);
         assert_eq!(enriched.len(), 4);
     }
 
@@ -690,7 +691,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures, &file_path, Some(&declared), &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, Some(&declared), &opts);
         let names: Vec<&str> = enriched.iter().map(|e| e.fixture.name.as_str()).collect();
         assert_eq!(names, vec!["app"]);
     }
@@ -712,7 +713,7 @@ mod tests {
             current_fixture_name: None,
             insert_prefix: "",
         };
-        let enriched = filter_and_enrich_fixtures(fixtures, &file_path, None, &opts);
+        let enriched = filter_and_enrich_fixtures(&fixtures, &file_path, None, &opts);
         let names: Vec<&str> = enriched.iter().map(|e| e.fixture.name.as_str()).collect();
         assert_eq!(names, vec!["real_fixture"]);
     }
@@ -853,16 +854,7 @@ mod tests {
         let slot_clone = backend_slot.clone();
         let (_svc, _sock) = LspService::new(move |client| {
             let b = Backend::new(client, db.clone());
-            // Clone all Arc fields to capture a usable Backend outside
-            *slot_clone.lock().unwrap() = Some(Backend {
-                client: b.client.clone(),
-                fixture_db: b.fixture_db.clone(),
-                workspace_root: b.workspace_root.clone(),
-                original_workspace_root: b.original_workspace_root.clone(),
-                scan_task: b.scan_task.clone(),
-                uri_cache: b.uri_cache.clone(),
-                config: b.config.clone(),
-            });
+            *slot_clone.lock().unwrap() = Some(b.clone());
             b
         });
         let result = backend_slot

--- a/src/providers/definition.rs
+++ b/src/providers/definition.rs
@@ -25,11 +25,11 @@ impl Backend {
                 file_path, position.line, position.character
             );
 
-            if let Some(definition) = self.fixture_db.find_fixture_definition(
-                &file_path,
-                position.line,
-                position.character,
-            ) {
+            let byte_col = self.to_byte_col(&file_path, position);
+            if let Some(definition) =
+                self.fixture_db
+                    .find_fixture_definition(&file_path, position.line, byte_col)
+            {
                 info!("Found definition: {:?}", definition);
                 let Some(def_uri) = self.path_to_uri(&definition.file_path) else {
                     return Ok(None);

--- a/src/providers/diagnostics.rs
+++ b/src/providers/diagnostics.rs
@@ -21,9 +21,9 @@ impl Backend {
                 diagnostics.push(Diagnostic {
                     range: Self::create_range(
                         line,
-                        fixture.start_char as u32,
+                        self.to_lsp_col(file_path, fixture.line, fixture.start_char),
                         line,
-                        fixture.end_char as u32,
+                        self.to_lsp_col(file_path, fixture.line, fixture.end_char),
                     ),
                     severity: Some(DiagnosticSeverity::WARNING),
                     code: Some(NumberOrString::String("undeclared-fixture".to_string())),
@@ -49,9 +49,9 @@ impl Backend {
                 diagnostics.push(Diagnostic {
                     range: Self::create_range(
                         line,
-                        cycle.fixture.start_char as u32,
+                        self.to_lsp_col(file_path, cycle.fixture.line, cycle.fixture.start_char),
                         line,
-                        cycle.fixture.end_char as u32,
+                        self.to_lsp_col(file_path, cycle.fixture.line, cycle.fixture.end_char),
                     ),
                     severity: Some(DiagnosticSeverity::ERROR),
                     code: Some(NumberOrString::String("circular-dependency".to_string())),
@@ -73,9 +73,17 @@ impl Backend {
                 diagnostics.push(Diagnostic {
                     range: Self::create_range(
                         line,
-                        mismatch.fixture.start_char as u32,
+                        self.to_lsp_col(
+                            file_path,
+                            mismatch.fixture.line,
+                            mismatch.fixture.start_char,
+                        ),
                         line,
-                        mismatch.fixture.end_char as u32,
+                        self.to_lsp_col(
+                            file_path,
+                            mismatch.fixture.line,
+                            mismatch.fixture.end_char,
+                        ),
                     ),
                     severity: Some(DiagnosticSeverity::WARNING),
                     code: Some(NumberOrString::String("scope-mismatch".to_string())),

--- a/src/providers/document_symbol.rs
+++ b/src/providers/document_symbol.rs
@@ -25,12 +25,22 @@ impl Backend {
             return Ok(None);
         };
 
-        // Collect all fixture definitions for this file
+        // Collect all fixture definitions for this file using the
+        // file_definitions reverse index (avoids scanning the whole workspace).
         let mut symbols: Vec<DocumentSymbol> = Vec::new();
 
-        // Iterate over all fixture definitions
-        for entry in self.fixture_db.definitions.iter() {
-            for definition in entry.value() {
+        let fixture_names: Vec<String> = self
+            .fixture_db
+            .file_definitions
+            .get(&file_path)
+            .map(|entry| entry.value().iter().cloned().collect())
+            .unwrap_or_default();
+
+        for name in &fixture_names {
+            let Some(defs) = self.fixture_db.definitions.get(name) else {
+                continue;
+            };
+            for definition in defs.value() {
                 // Only include fixtures from this file
                 if definition.file_path != file_path {
                     continue;
@@ -42,8 +52,9 @@ impl Backend {
                 }
 
                 let line = Self::internal_line_to_lsp(definition.line);
-                let start_char = definition.start_char as u32;
-                let end_char = definition.end_char as u32;
+                let start_char =
+                    self.to_lsp_col(&file_path, definition.line, definition.start_char);
+                let end_char = self.to_lsp_col(&file_path, definition.line, definition.end_char);
 
                 // Selection range is the fixture name
                 let selection_range = Self::create_range(line, start_char, line, end_char);

--- a/src/providers/hover.rs
+++ b/src/providers/hover.rs
@@ -22,11 +22,11 @@ impl Backend {
                 file_path, position.line, position.character
             );
 
-            if let Some(definition) = self.fixture_db.find_fixture_definition(
-                &file_path,
-                position.line,
-                position.character,
-            ) {
+            let byte_col = self.to_byte_col(&file_path, position);
+            if let Some(definition) =
+                self.fixture_db
+                    .find_fixture_definition(&file_path, position.line, byte_col)
+            {
                 info!("Found fixture definition for hover: {:?}", definition.name);
 
                 // Get workspace root for formatting documentation

--- a/src/providers/implementation.rs
+++ b/src/providers/implementation.rs
@@ -34,10 +34,11 @@ impl Backend {
             );
 
             // First find the fixture definition (works on both definitions and usages)
+            let byte_col = self.to_byte_col(&file_path, position);
             if let Some(definition) = self.fixture_db.find_fixture_or_definition_at_position(
                 &file_path,
                 position.line,
-                position.character,
+                byte_col,
             ) {
                 info!("Found definition: {:?}", definition);
 

--- a/src/providers/inlay_hint.rs
+++ b/src/providers/inlay_hint.rs
@@ -135,7 +135,7 @@ impl Backend {
                 hints.push(InlayHint {
                     position: Position {
                         line: lsp_line,
-                        character: usage.end_char as u32,
+                        character: self.to_lsp_col(&file_path, usage.line, usage.end_char),
                     },
                     label: InlayHintLabel::String(format!(": {}", display_type)),
                     kind: Some(InlayHintKind::TYPE),

--- a/src/providers/language_server.rs
+++ b/src/providers/language_server.rs
@@ -19,81 +19,103 @@ impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         info!("Initialize request received");
 
+        // Negotiate position encoding: internal columns are UTF-8 byte offsets,
+        // so prefer utf-8 when the client supports it and skip conversion entirely.
+        let client_supports_utf8 = params
+            .capabilities
+            .general
+            .as_ref()
+            .and_then(|g| g.position_encodings.as_ref())
+            .is_some_and(|encodings| encodings.contains(&PositionEncodingKind::UTF8));
+        self.client_utf16
+            .store(!client_supports_utf8, std::sync::atomic::Ordering::Relaxed);
+        let position_encoding = if client_supports_utf8 {
+            PositionEncodingKind::UTF8
+        } else {
+            PositionEncodingKind::UTF16
+        };
+
         // Scan the workspace for fixtures on initialization
         // This is done in a background task to avoid blocking the LSP initialization
         // Try workspace_folders first (preferred), fall back to deprecated root_uri
-        let root_uri = params
+        let root_uris: Vec<Uri> = params
             .workspace_folders
             .as_ref()
-            .and_then(|folders| folders.first())
-            .map(|folder| folder.uri.clone())
+            .map(|folders| folders.iter().map(|f| f.uri.clone()).collect())
+            .filter(|uris: &Vec<Uri>| !uris.is_empty())
             .or_else(|| {
                 #[allow(deprecated)]
-                params.root_uri.clone()
-            });
+                params.root_uri.clone().map(|uri| vec![uri])
+            })
+            .unwrap_or_default();
 
-        if let Some(root_uri) = root_uri {
-            if let Some(root_path) = root_uri.to_file_path() {
-                let root_path = root_path.to_path_buf();
-                info!("Starting workspace scan: {:?}", root_path);
+        let root_paths: Vec<std::path::PathBuf> = root_uris
+            .iter()
+            .filter_map(|uri| uri.to_file_path().map(|p| p.to_path_buf()))
+            .collect();
 
-                // Store the original workspace root (as client provided it)
-                *self.original_workspace_root.write().await = Some(root_path.clone());
+        if let Some(first_root) = root_paths.first().cloned() {
+            info!("Starting workspace scan: {:?}", root_paths);
 
-                // Store the canonical workspace root (with symlinks resolved)
-                let canonical_root = root_path
-                    .canonicalize()
-                    .unwrap_or_else(|_| root_path.clone());
-                *self.workspace_root.write().await = Some(canonical_root.clone());
+            // Store the original workspace root (as client provided it).
+            // Config and relative-path display use the first folder.
+            *self.original_workspace_root.write().await = Some(first_root.clone());
 
-                // Load configuration from pyproject.toml
-                let loaded_config = config::Config::load(&root_path);
-                info!("Loaded config: {:?}", loaded_config);
-                *self.config.write().await = loaded_config;
+            // Store the canonical workspace root (with symlinks resolved)
+            let canonical_root = first_root
+                .canonicalize()
+                .unwrap_or_else(|_| first_root.clone());
+            *self.workspace_root.write().await = Some(canonical_root.clone());
 
-                // Clone references for the background task
-                let fixture_db = Arc::clone(&self.fixture_db);
-                let client = self.client.clone();
-                let exclude_patterns = self.config.read().await.exclude.clone();
+            // Load configuration from pyproject.toml
+            let loaded_config = config::Config::load(&first_root);
+            info!("Loaded config: {:?}", loaded_config);
+            *self.config.write().await = loaded_config;
 
-                // Spawn workspace scanning in a background task
-                // This allows the LSP to respond immediately while scanning continues
-                let scan_handle = tokio::spawn(async move {
-                    client
-                        .log_message(
-                            MessageType::INFO,
-                            format!("Scanning workspace: {:?}", root_path),
-                        )
-                        .await;
+            // Clone references for the background task
+            let fixture_db = Arc::clone(&self.fixture_db);
+            let client = self.client.clone();
+            let exclude_patterns = self.config.read().await.exclude.clone();
 
-                    // Run the synchronous scan in a blocking task to avoid blocking the async runtime
-                    let scan_result = tokio::task::spawn_blocking(move || {
-                        fixture_db.scan_workspace_with_excludes(&root_path, &exclude_patterns);
-                    })
+            // Spawn workspace scanning in a background task
+            // This allows the LSP to respond immediately while scanning continues
+            let scan_handle = tokio::spawn(async move {
+                client
+                    .log_message(
+                        MessageType::INFO,
+                        format!("Scanning workspace: {:?}", root_paths),
+                    )
                     .await;
 
-                    match scan_result {
-                        Ok(()) => {
-                            info!("Workspace scan complete");
-                            client
-                                .log_message(MessageType::INFO, "Workspace scan complete")
-                                .await;
-                        }
-                        Err(e) => {
-                            error!("Workspace scan failed: {:?}", e);
-                            client
-                                .log_message(
-                                    MessageType::ERROR,
-                                    format!("Workspace scan failed: {:?}", e),
-                                )
-                                .await;
-                        }
+                // Run the synchronous scan in a blocking task to avoid blocking the async runtime
+                let scan_result = tokio::task::spawn_blocking(move || {
+                    for root_path in &root_paths {
+                        fixture_db.scan_workspace_with_excludes(root_path, &exclude_patterns);
                     }
-                });
+                })
+                .await;
 
-                // Store the handle so we can cancel it on shutdown
-                *self.scan_task.lock().await = Some(scan_handle);
-            }
+                match scan_result {
+                    Ok(()) => {
+                        info!("Workspace scan complete");
+                        client
+                            .log_message(MessageType::INFO, "Workspace scan complete")
+                            .await;
+                    }
+                    Err(e) => {
+                        error!("Workspace scan failed: {:?}", e);
+                        client
+                            .log_message(
+                                MessageType::ERROR,
+                                format!("Workspace scan failed: {:?}", e),
+                            )
+                            .await;
+                    }
+                }
+            });
+
+            // Store the handle so we can cancel it on shutdown
+            *self.scan_task.lock().await = Some(scan_handle);
         } else {
             warn!("No root URI provided in initialize - workspace scanning disabled");
             self.client
@@ -111,6 +133,7 @@ impl LanguageServer for Backend {
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
             capabilities: ServerCapabilities {
+                position_encoding: Some(position_encoding),
                 definition_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
@@ -222,18 +245,38 @@ impl LanguageServer for Backend {
                 self.fixture_db
                     .analyze_file(file_path.clone(), &change.text);
 
-                // Publish diagnostics for undeclared fixtures
-                self.publish_diagnostics_for_file(&uri, &file_path).await;
+                // Debounce the follow-on work (cycle/scope diagnostics and the
+                // inlay-hint refresh round trip) so rapid keystrokes coalesce
+                // into a single pass once typing pauses.
+                let generation = {
+                    let mut entry = self.change_generation.entry(file_path.clone()).or_insert(0);
+                    *entry += 1;
+                    *entry
+                };
 
-                // Request inlay hint refresh so editors update hints after edits
-                // (e.g., when user adds/removes type annotations)
-                if let Err(e) = self.client.inlay_hint_refresh().await {
-                    // Not all clients support this, so just log and continue
-                    info!(
-                        "Inlay hint refresh request failed (client may not support it): {}",
-                        e
-                    );
-                }
+                let backend = self.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+                    // A newer change superseded this one — its task will publish.
+                    let current = backend.change_generation.get(&file_path).map(|g| *g);
+                    if current != Some(generation) {
+                        return;
+                    }
+
+                    // Publish diagnostics for undeclared fixtures
+                    backend.publish_diagnostics_for_file(&uri, &file_path).await;
+
+                    // Request inlay hint refresh so editors update hints after edits
+                    // (e.g., when user adds/removes type annotations)
+                    if let Err(e) = backend.client.inlay_hint_refresh().await {
+                        // Not all clients support this, so just log and continue
+                        info!(
+                            "Inlay hint refresh request failed (client may not support it): {}",
+                            e
+                        );
+                    }
+                });
             }
         }
     }
@@ -310,6 +353,13 @@ impl LanguageServer for Backend {
             self.fixture_db.cleanup_file_cache(&file_path);
             // Clean up URI cache entry
             self.uri_cache.remove(&file_path);
+            // Drop the debounce counter for this file
+            self.change_generation.remove(&file_path);
+
+            // Clear published diagnostics so closed files don't show stale warnings
+            self.client
+                .publish_diagnostics(uri.clone(), Vec::new(), None)
+                .await;
         }
     }
 

--- a/src/providers/language_server.rs
+++ b/src/providers/language_server.rs
@@ -268,9 +268,11 @@ impl LanguageServer for Backend {
                     backend.publish_diagnostics_for_file(&uri, &file_path).await;
 
                     // If the file was closed while we were publishing (did_close
-                    // removes the generation entry), re-clear so a closed file
-                    // never ends up showing stale diagnostics.
-                    if backend.change_generation.get(&file_path).is_none() {
+                    // removes it from uri_cache), re-clear so a closed file never
+                    // ends up showing stale diagnostics. Checking uri_cache rather
+                    // than the generation entry means a close-then-reopen during
+                    // the publish doesn't wipe the reopened file's diagnostics.
+                    if !backend.uri_cache.contains_key(&file_path) {
                         backend
                             .client
                             .publish_diagnostics(uri.clone(), Vec::new(), None)

--- a/src/providers/language_server.rs
+++ b/src/providers/language_server.rs
@@ -267,6 +267,17 @@ impl LanguageServer for Backend {
                     // Publish diagnostics for undeclared fixtures
                     backend.publish_diagnostics_for_file(&uri, &file_path).await;
 
+                    // If the file was closed while we were publishing (did_close
+                    // removes the generation entry), re-clear so a closed file
+                    // never ends up showing stale diagnostics.
+                    if backend.change_generation.get(&file_path).is_none() {
+                        backend
+                            .client
+                            .publish_diagnostics(uri.clone(), Vec::new(), None)
+                            .await;
+                        return;
+                    }
+
                     // Request inlay hint refresh so editors update hints after edits
                     // (e.g., when user adds/removes type annotations)
                     if let Err(e) = backend.client.inlay_hint_refresh().await {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -21,10 +21,43 @@ use crate::config::Config;
 use crate::fixtures::FixtureDatabase;
 use dashmap::DashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tower_lsp_server::ls_types::*;
 use tower_lsp_server::Client;
 use tracing::warn;
+
+/// Convert a UTF-16 column to a byte offset within `line`.
+/// Columns past the end of the line clamp to the line's byte length.
+pub(crate) fn utf16_col_to_byte(line: &str, utf16_col: usize) -> usize {
+    if line.is_ascii() {
+        return utf16_col.min(line.len());
+    }
+    let mut units = 0usize;
+    for (byte_idx, ch) in line.char_indices() {
+        if units >= utf16_col {
+            return byte_idx;
+        }
+        units += ch.len_utf16();
+    }
+    line.len()
+}
+
+/// Convert a byte offset within `line` to a UTF-16 column.
+/// Offsets past the end of the line clamp to the line's UTF-16 length.
+pub(crate) fn byte_col_to_utf16(line: &str, byte_col: usize) -> usize {
+    if line.is_ascii() {
+        return byte_col.min(line.len());
+    }
+    let mut units = 0usize;
+    for (byte_idx, ch) in line.char_indices() {
+        if byte_idx >= byte_col {
+            break;
+        }
+        units += ch.len_utf16();
+    }
+    units
+}
 
 /// The LSP Backend struct containing server state.
 pub struct Backend {
@@ -41,6 +74,29 @@ pub struct Backend {
     pub uri_cache: Arc<DashMap<PathBuf, Uri>>,
     /// Configuration loaded from pyproject.toml
     pub config: Arc<tokio::sync::RwLock<Config>>,
+    /// Whether the client uses UTF-16 position encoding (the LSP default).
+    /// Set to false during initialize when the client supports UTF-8, in which
+    /// case our internal byte columns can be sent as-is.
+    pub client_utf16: Arc<AtomicBool>,
+    /// Per-file change generation counters used to debounce diagnostics
+    /// publishing while the user is typing.
+    pub change_generation: Arc<DashMap<PathBuf, u64>>,
+}
+
+impl Clone for Backend {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            fixture_db: Arc::clone(&self.fixture_db),
+            workspace_root: Arc::clone(&self.workspace_root),
+            original_workspace_root: Arc::clone(&self.original_workspace_root),
+            scan_task: Arc::clone(&self.scan_task),
+            uri_cache: Arc::clone(&self.uri_cache),
+            config: Arc::clone(&self.config),
+            client_utf16: Arc::clone(&self.client_utf16),
+            change_generation: Arc::clone(&self.change_generation),
+        }
+    }
 }
 
 impl Backend {
@@ -54,6 +110,48 @@ impl Backend {
             scan_task: Arc::new(tokio::sync::Mutex::new(None)),
             uri_cache: Arc::new(DashMap::new()),
             config: Arc::new(tokio::sync::RwLock::new(Config::default())),
+            client_utf16: Arc::new(AtomicBool::new(true)),
+            change_generation: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Get the text of a 1-based line in a file (without the trailing newline).
+    fn line_text(&self, file_path: &std::path::Path, internal_line: usize) -> Option<String> {
+        let content = self.fixture_db.get_file_content(file_path)?;
+        let index = self.fixture_db.get_line_index(file_path, &content);
+        let start = *index.get(internal_line.checked_sub(1)?)?;
+        let end = index.get(internal_line).copied().unwrap_or(content.len());
+        Some(
+            content[start..end]
+                .trim_end_matches(['\r', '\n'])
+                .to_string(),
+        )
+    }
+
+    /// Convert an inbound LSP position's character to an internal byte column.
+    pub(crate) fn to_byte_col(&self, file_path: &std::path::Path, position: Position) -> u32 {
+        if !self.client_utf16.load(Ordering::Relaxed) {
+            return position.character;
+        }
+        match self.line_text(file_path, Self::lsp_line_to_internal(position.line)) {
+            Some(line) => utf16_col_to_byte(&line, position.character as usize) as u32,
+            None => position.character,
+        }
+    }
+
+    /// Convert an internal byte column to an outbound LSP character.
+    pub(crate) fn to_lsp_col(
+        &self,
+        file_path: &std::path::Path,
+        internal_line: usize,
+        byte_col: usize,
+    ) -> u32 {
+        if !self.client_utf16.load(Ordering::Relaxed) {
+            return byte_col as u32;
+        }
+        match self.line_text(file_path, internal_line) {
+            Some(line) => byte_col_to_utf16(&line, byte_col) as u32,
+            None => byte_col as u32,
         }
     }
 
@@ -83,17 +181,18 @@ impl Backend {
             return Some(cached_uri.clone());
         }
 
-        // For paths not in cache, we need to handle macOS symlink issue
-        // where /var is a symlink to /private/var
-        // The client sends /var/... but we store /private/var/...
-        // So we need to strip /private prefix when building URIs
+        // For paths not in cache, we need to handle the macOS symlink issue
+        // where /var, /tmp, /etc are symlinks into /private. The client sends
+        // /var/... but we store the canonical /private/var/..., so strip the
+        // /private prefix when the stripped path resolves back to the same file.
         let path_to_use: Option<PathBuf> = if cfg!(target_os = "macos") {
             path.to_str().and_then(|path_str| {
-                if path_str.starts_with("/private/var/") || path_str.starts_with("/private/tmp/") {
-                    Some(PathBuf::from(path_str.replacen("/private", "", 1)))
-                } else {
-                    None
+                let stripped = path_str.strip_prefix("/private")?;
+                if !stripped.starts_with('/') {
+                    return None;
                 }
+                let candidate = PathBuf::from(stripped);
+                (candidate.canonicalize().ok()? == *path).then_some(candidate)
             })
         } else if cfg!(target_os = "windows") {
             // Strip Windows extended-length path prefix (\\?\) which is added by canonicalize()
@@ -200,5 +299,42 @@ impl Backend {
         }
 
         content
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{byte_col_to_utf16, utf16_col_to_byte};
+
+    #[test]
+    fn test_utf16_byte_conversion_ascii() {
+        let line = "def test(fixture):";
+        assert_eq!(utf16_col_to_byte(line, 9), 9);
+        assert_eq!(byte_col_to_utf16(line, 9), 9);
+        // Clamps past end of line.
+        assert_eq!(utf16_col_to_byte(line, 100), line.len());
+        assert_eq!(byte_col_to_utf16(line, 100), line.len());
+    }
+
+    #[test]
+    fn test_utf16_byte_conversion_bmp() {
+        // "é" is 2 bytes in UTF-8 but 1 UTF-16 code unit.
+        let line = "x = 'é'; fixture";
+        assert_eq!(utf16_col_to_byte(line, 9), 10);
+        assert_eq!(byte_col_to_utf16(line, 10), 9);
+    }
+
+    #[test]
+    fn test_utf16_byte_conversion_astral() {
+        // "🎉" is 4 bytes in UTF-8 and 2 UTF-16 code units (surrogate pair);
+        // it starts at byte 5 / UTF-16 unit 5 and ends at byte 9 / unit 7.
+        let line = "s = '🎉'; f";
+        assert_eq!(utf16_col_to_byte(line, 7), 9);
+        assert_eq!(byte_col_to_utf16(line, 9), 7);
+        // "f" is at byte 12 / UTF-16 unit 10.
+        assert_eq!(utf16_col_to_byte(line, 10), 12);
+        assert_eq!(byte_col_to_utf16(line, 12), 10);
+        // A column inside the surrogate pair snaps to the next boundary.
+        assert_eq!(utf16_col_to_byte(line, 6), 9);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -115,17 +115,21 @@ impl Backend {
         }
     }
 
-    /// Get the text of a 1-based line in a file (without the trailing newline).
-    fn line_text(&self, file_path: &std::path::Path, internal_line: usize) -> Option<String> {
+    /// Run `f` on the text of a 1-based line (without the trailing newline).
+    /// Borrows straight from the cached content Arc — no per-call allocation —
+    /// and uses the identity-keyed line index so the file is not re-hashed on
+    /// every column conversion.
+    fn with_line_text<R>(
+        &self,
+        file_path: &std::path::Path,
+        internal_line: usize,
+        f: impl FnOnce(&str) -> R,
+    ) -> Option<R> {
         let content = self.fixture_db.get_file_content(file_path)?;
-        let index = self.fixture_db.get_line_index(file_path, &content);
+        let index = self.fixture_db.get_line_index_for(file_path, &content);
         let start = *index.get(internal_line.checked_sub(1)?)?;
         let end = index.get(internal_line).copied().unwrap_or(content.len());
-        Some(
-            content[start..end]
-                .trim_end_matches(['\r', '\n'])
-                .to_string(),
-        )
+        Some(f(content[start..end].trim_end_matches(['\r', '\n'])))
     }
 
     /// Convert an inbound LSP position's character to an internal byte column.
@@ -133,10 +137,12 @@ impl Backend {
         if !self.client_utf16.load(Ordering::Relaxed) {
             return position.character;
         }
-        match self.line_text(file_path, Self::lsp_line_to_internal(position.line)) {
-            Some(line) => utf16_col_to_byte(&line, position.character as usize) as u32,
-            None => position.character,
-        }
+        self.with_line_text(
+            file_path,
+            Self::lsp_line_to_internal(position.line),
+            |line| utf16_col_to_byte(line, position.character as usize) as u32,
+        )
+        .unwrap_or(position.character)
     }
 
     /// Convert an internal byte column to an outbound LSP character.
@@ -149,10 +155,10 @@ impl Backend {
         if !self.client_utf16.load(Ordering::Relaxed) {
             return byte_col as u32;
         }
-        match self.line_text(file_path, internal_line) {
-            Some(line) => byte_col_to_utf16(&line, byte_col) as u32,
-            None => byte_col as u32,
-        }
+        self.with_line_text(file_path, internal_line, |line| {
+            byte_col_to_utf16(line, byte_col) as u32
+        })
+        .unwrap_or(byte_col as u32)
     }
 
     /// Convert URI to PathBuf with error logging

--- a/src/providers/references.rs
+++ b/src/providers/references.rs
@@ -26,11 +26,11 @@ impl Backend {
             );
 
             // First, find which fixture we're looking at (definition or usage)
-            if let Some(fixture_name) = self.fixture_db.find_fixture_at_position(
-                &file_path,
-                position.line,
-                position.character,
-            ) {
+            let byte_col = self.to_byte_col(&file_path, position);
+            if let Some(fixture_name) =
+                self.fixture_db
+                    .find_fixture_at_position(&file_path, position.line, byte_col)
+            {
                 info!(
                     "Found fixture: {}, determining which definition to use",
                     fixture_name
@@ -44,11 +44,9 @@ impl Backend {
 
                 // Determine which specific definition the user is referring to
                 // This could be a usage (resolve to definition) or clicking on a definition itself
-                let target_definition = self.fixture_db.find_fixture_definition(
-                    &file_path,
-                    position.line,
-                    position.character,
-                );
+                let target_definition =
+                    self.fixture_db
+                        .find_fixture_definition(&file_path, position.line, byte_col);
 
                 let (references, definition_to_include) = if let Some(definition) =
                     target_definition
@@ -160,9 +158,17 @@ impl Backend {
                         uri: ref_uri,
                         range: Self::create_range(
                             ref_line,
-                            reference.start_char as u32,
+                            self.to_lsp_col(
+                                &reference.file_path,
+                                reference.line,
+                                reference.start_char,
+                            ),
                             ref_line,
-                            reference.end_char as u32,
+                            self.to_lsp_col(
+                                &reference.file_path,
+                                reference.line,
+                                reference.end_char,
+                            ),
                         ),
                     };
                     debug!(

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -304,7 +304,17 @@ impl Backend {
         };
 
         let line_index = FixtureDatabase::build_line_index(content);
-        let cursor_offset = *line_index.get(position.line as usize)? + position.character as usize;
+        let line_start = *line_index.get(position.line as usize)?;
+        let line_end = line_index
+            .get(position.line as usize + 1)
+            .copied()
+            .unwrap_or(content.len());
+        let cursor_byte_col = if self.client_utf16.load(std::sync::atomic::Ordering::Relaxed) {
+            super::utf16_col_to_byte(&content[line_start..line_end], position.character as usize)
+        } else {
+            position.character as usize
+        };
+        let cursor_offset = line_start + cursor_byte_col;
 
         // Innermost *parametrized* function whose decorators or body contain the cursor. Filtering
         // to parametrized functions means a cursor inside a nested closure that references the
@@ -396,7 +406,7 @@ impl Backend {
             .copied()
             .unwrap_or(occurrences[0]);
 
-        let to_lsp = |tr: &TextRange| self.text_range_to_lsp(tr, &line_index);
+        let to_lsp = |tr: &TextRange| self.text_range_to_lsp(tr, content, &line_index);
         Some(RenameTarget {
             cursor_token: to_lsp(&cursor_tr),
             edits: occurrences.iter().map(to_lsp).collect(),
@@ -404,28 +414,28 @@ impl Backend {
     }
 
     /// Convert a source [`TextRange`] into an LSP [`Range`] using the file's line index.
-    fn text_range_to_lsp(&self, tr: &TextRange, line_index: &[usize]) -> Range {
-        let start_offset = tr.start().to_usize();
-        let end_offset = tr.end().to_usize();
-        let start_line = self
-            .fixture_db
-            .get_line_from_offset(start_offset, line_index);
-        let end_line = self.fixture_db.get_line_from_offset(end_offset, line_index);
+    fn text_range_to_lsp(&self, tr: &TextRange, content: &str, line_index: &[usize]) -> Range {
+        let utf16 = self.client_utf16.load(std::sync::atomic::Ordering::Relaxed);
+        let to_position = |offset: usize| {
+            let line = self.fixture_db.get_line_from_offset(offset, line_index);
+            let byte_col = self
+                .fixture_db
+                .get_char_position_from_offset(offset, line_index);
+            let character = if utf16 {
+                let line_start = line_index[line - 1];
+                let line_end = line_index.get(line).copied().unwrap_or(content.len());
+                super::byte_col_to_utf16(&content[line_start..line_end], byte_col) as u32
+            } else {
+                byte_col as u32
+            };
+            Position {
+                line: (line - 1) as u32,
+                character,
+            }
+        };
         Range {
-            start: Position {
-                line: (start_line - 1) as u32,
-                character: self
-                    .fixture_db
-                    .get_char_position_from_offset(start_offset, line_index)
-                    as u32,
-            },
-            end: Position {
-                line: (end_line - 1) as u32,
-                character: self
-                    .fixture_db
-                    .get_char_position_from_offset(end_offset, line_index)
-                    as u32,
-            },
+            start: to_position(tr.start().to_usize()),
+            end: to_position(tr.end().to_usize()),
         }
     }
 }
@@ -489,12 +499,15 @@ fn collect_functions<'a>(stmts: &'a [Stmt], out: &mut Vec<FuncCtx<'a>>) {
 }
 
 fn is_valid_python_identifier(name: &str) -> bool {
+    // Approximates Python's XID_Start/XID_Continue rules with Unicode
+    // alphanumerics — accepts legal identifiers like `café` without pulling
+    // in a unicode-ident dependency.
     let mut chars = name.chars();
     match chars.next() {
-        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        Some(c) if c == '_' || c.is_alphabetic() => {}
         _ => return false,
     }
-    if !chars.all(|c| c == '_' || c.is_ascii_alphanumeric()) {
+    if !chars.all(|c| c == '_' || c.is_alphanumeric()) {
         return false;
     }
     !PYTHON_KEYWORDS.contains(&name)

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -309,10 +309,13 @@ impl Backend {
             .get(position.line as usize + 1)
             .copied()
             .unwrap_or(content.len());
+        // Trim the line ending and clamp so an out-of-range column resolves to
+        // the logical end of the line instead of landing on the newline.
+        let line = content[line_start..line_end].trim_end_matches(['\r', '\n']);
         let cursor_byte_col = if self.client_utf16.load(std::sync::atomic::Ordering::Relaxed) {
-            super::utf16_col_to_byte(&content[line_start..line_end], position.character as usize)
+            super::utf16_col_to_byte(line, position.character as usize)
         } else {
-            position.character as usize
+            (position.character as usize).min(line.len())
         };
         let cursor_offset = line_start + cursor_byte_col;
 

--- a/src/providers/rename.rs
+++ b/src/providers/rename.rs
@@ -447,26 +447,37 @@ fn range_contains(range: &TextRange, offset: usize) -> bool {
     range.start().to_usize() <= offset && offset <= range.end().to_usize()
 }
 
-/// Returns the ASCII identifier spanning `offset` in `content`, treating `offset` inclusively so
+/// Returns the identifier spanning `offset` in `content`, treating `offset` inclusively so
 /// a caret resting just past the last character (a common rename position) still resolves.
 ///
-/// Works in byte offsets to stay consistent with the rest of this provider; identifiers are ASCII
-/// so this never splits a multi-byte character.
+/// Works in byte offsets to stay consistent with the rest of this provider, but is
+/// Unicode-aware (matching `is_valid_python_identifier`); an offset inside a multi-byte
+/// character is floored to its start.
 fn identifier_at(content: &str, offset: usize) -> Option<String> {
-    let bytes = content.as_bytes();
-    if offset > bytes.len() {
+    if offset > content.len() {
         return None;
     }
-    let is_word = |b: u8| b == b'_' || b.is_ascii_alphanumeric();
+    let mut idx = offset;
+    while idx > 0 && !content.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    let is_word = |c: char| c == '_' || c.is_alphanumeric();
 
-    let mut start = offset;
-    while start > 0 && is_word(bytes[start - 1]) {
-        start -= 1;
-    }
-    let mut end = offset;
-    while end < bytes.len() && is_word(bytes[end]) {
-        end += 1;
-    }
+    let start = content[..idx]
+        .char_indices()
+        .rev()
+        .take_while(|(_, c)| is_word(*c))
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(idx);
+    let end = idx
+        + content[idx..]
+            .char_indices()
+            .take_while(|(_, c)| is_word(*c))
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+
     if start == end {
         return None;
     }

--- a/src/providers/workspace_symbol.rs
+++ b/src/providers/workspace_symbol.rs
@@ -42,8 +42,13 @@ impl Backend {
                 };
 
                 let line = Self::internal_line_to_lsp(definition.line);
-                let start_char = definition.start_char as u32;
-                let end_char = definition.end_char as u32;
+                let start_char = self.to_lsp_col(
+                    &definition.file_path,
+                    definition.line,
+                    definition.start_char,
+                );
+                let end_char =
+                    self.to_lsp_col(&definition.file_path, definition.line, definition.end_char);
 
                 let location = Location {
                     uri,

--- a/tests/test_decorators.rs
+++ b/tests/test_decorators.rs
@@ -135,10 +135,32 @@ fn test_extract_usefixtures() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] {
-            let names = decorators::extract_usefixtures_names(&func_def.decorator_list[0]);
+            let names = decorators::extract_usefixtures_names(&func_def.decorator_list[0], code);
             assert_eq!(names.len(), 2);
             assert_eq!(names[0].0, "f1");
             assert_eq!(names[1].0, "f2");
+        }
+    }
+}
+
+#[test]
+#[timeout(30000)]
+fn test_extract_usefixtures_ranges_cover_exact_names() {
+    // Ranges must cover exactly the fixture name for any quote style,
+    // including prefixed (r"...") and triple-quoted ("""...""") literals.
+    let code = "@pytest.mark.usefixtures('f1', r'f2', \"\"\"f3\"\"\")\ndef test_x(): pass";
+    let parsed = parse(code, Mode::Module, "").unwrap();
+
+    if let rustpython_parser::ast::Mod::Module(module) = parsed {
+        if let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] {
+            let names = decorators::extract_usefixtures_names(&func_def.decorator_list[0], code);
+            assert_eq!(names.len(), 3);
+            for (name, range) in &names {
+                let span = &code[range.start().to_usize()..range.end().to_usize()];
+                assert_eq!(span, name, "range must cover exactly the fixture name");
+            }
+        } else {
+            panic!("expected function def");
         }
     }
 }
@@ -151,7 +173,7 @@ fn test_extract_usefixtures_from_expr_direct_call() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::Assign(assign) = &module.body[0] {
-            let names = decorators::extract_usefixtures_from_expr(&assign.value);
+            let names = decorators::extract_usefixtures_from_expr(&assign.value, code);
             assert_eq!(names.len(), 2);
             assert_eq!(names[0].0, "f1");
             assert_eq!(names[1].0, "f2");
@@ -167,7 +189,7 @@ fn test_extract_usefixtures_from_expr_list() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::Assign(assign) = &module.body[0] {
-            let names = decorators::extract_usefixtures_from_expr(&assign.value);
+            let names = decorators::extract_usefixtures_from_expr(&assign.value, code);
             assert_eq!(names.len(), 2);
             assert_eq!(names[0].0, "f1");
             assert_eq!(names[1].0, "f2");
@@ -183,7 +205,7 @@ fn test_extract_usefixtures_from_expr_tuple() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::Assign(assign) = &module.body[0] {
-            let names = decorators::extract_usefixtures_from_expr(&assign.value);
+            let names = decorators::extract_usefixtures_from_expr(&assign.value, code);
             assert_eq!(names.len(), 2);
             assert_eq!(names[0].0, "f1");
             assert_eq!(names[1].0, "f2");
@@ -199,7 +221,7 @@ fn test_extract_usefixtures_from_expr_no_usefixtures() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::Assign(assign) = &module.body[0] {
-            let names = decorators::extract_usefixtures_from_expr(&assign.value);
+            let names = decorators::extract_usefixtures_from_expr(&assign.value, code);
             assert_eq!(names.len(), 0);
         }
     }
@@ -228,10 +250,18 @@ fn test_extract_parametrize_indirect() {
 
     if let rustpython_parser::ast::Mod::Module(module) = parsed {
         if let rustpython_parser::ast::Stmt::FunctionDef(func_def) = &module.body[0] {
-            let fixtures =
-                decorators::extract_parametrize_indirect_fixtures(&func_def.decorator_list[0]);
+            let fixtures = decorators::extract_parametrize_indirect_fixtures(
+                &func_def.decorator_list[0],
+                code,
+            );
             assert_eq!(fixtures.len(), 1);
             assert_eq!(fixtures[0].0, "f1");
+            // The range must point at the name token itself, not the whole literal.
+            let (name, range) = &fixtures[0];
+            assert_eq!(
+                &code[range.start().to_usize()..range.end().to_usize()],
+                name
+            );
         }
     }
 }

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -4,6 +4,7 @@
 
 use ntest::timeout;
 use pytest_language_server::FixtureDatabase;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 #[test]
@@ -12265,15 +12266,15 @@ pytest_plugins = ["module_b"]
     db.analyze_file(conftest_path.clone(), conftest_content);
 
     // Only module_b should be imported via conftest (last assignment wins)
-    let imported = db.is_fixture_imported_in_file("fixture_b", &conftest_path);
+    let mut visited = HashSet::new();
+    let imported = db.get_imported_fixtures(&conftest_path, &mut visited);
     assert!(
-        imported,
+        imported.contains_key("fixture_b"),
         "fixture_b should be imported (last pytest_plugins assignment)"
     );
 
-    let imported_a = db.is_fixture_imported_in_file("fixture_a", &conftest_path);
     assert!(
-        !imported_a,
+        !imported.contains_key("fixture_a"),
         "fixture_a should NOT be imported (overwritten by second pytest_plugins)"
     );
 }
@@ -13427,7 +13428,7 @@ def my_session_fixture():
     // fixture can only depend on other session-scoped fixtures.
     let available = db.get_available_fixtures(&test_path);
     let filtered: Vec<_> = available
-        .into_iter()
+        .iter()
         .filter(|f| f.scope >= FixtureScope::Session)
         .collect();
 
@@ -13509,7 +13510,7 @@ def my_module_fixture():
     // and class, but allow module, package, and session.
     let available = db.get_available_fixtures(&test_path);
     let filtered: Vec<_> = available
-        .into_iter()
+        .iter()
         .filter(|f| f.scope >= FixtureScope::Module)
         .collect();
 
@@ -13591,7 +13592,7 @@ def my_func_fixture():
     // Simulate scope filtering: function scope allows all scopes (>= Function)
     let available = db.get_available_fixtures(&test_path);
     let filtered: Vec<_> = available
-        .into_iter()
+        .iter()
         .filter(|f| f.scope >= FixtureScope::Function)
         .collect();
 
@@ -15208,4 +15209,53 @@ fn test_completion_context_text_fallback_fixture_scope_single_quotes() {
             other
         ),
     }
+}
+
+// ── Cache eviction ──────────────────────────────────────────────────────
+
+#[test]
+#[timeout(120000)]
+fn test_file_cache_eviction_bounds_cache_size() {
+    let db = FixtureDatabase::new();
+    let base = PathBuf::from("/tmp/pls_eviction_test");
+
+    // MAX_FILE_CACHE_SIZE is 2000; exceed it enough to trigger bulk eviction.
+    let total = 2101;
+    for i in 0..total {
+        let path = base.join(format!("test_file_{i}.py"));
+        db.analyze_file(path, "x = 1\n");
+    }
+
+    assert!(
+        db.file_cache.len() <= 2000,
+        "file cache exceeded its bound: {}",
+        db.file_cache.len()
+    );
+
+    // The most recently analyzed file must never be evicted.
+    let last = base.join(format!("test_file_{}.py", total - 1));
+    assert!(
+        db.file_cache.contains_key(&last),
+        "the just-analyzed file must be retained"
+    );
+
+    // Related caches must be cleaned alongside evicted file_cache entries.
+    let mut evicted = 0;
+    for i in 0..total {
+        let path = base.join(format!("test_file_{i}.py"));
+        if !db.file_cache.contains_key(&path) {
+            evicted += 1;
+            assert!(
+                !db.ast_cache.contains_key(&path),
+                "ast_cache must not retain evicted file {:?}",
+                path
+            );
+            assert!(
+                !db.line_index_cache.contains_key(&path),
+                "line_index_cache must not retain evicted file {:?}",
+                path
+            );
+        }
+    }
+    assert!(evicted > 0, "expected at least one eviction");
 }

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -15291,3 +15291,44 @@ fn test_explicit_import_resolves_to_reexporting_source() {
         "the fixture must be attributed to the file that defines it"
     );
 }
+
+#[test]
+#[timeout(30000)]
+fn test_explicit_then_star_import_keeps_transitive_fixtures() {
+    // An explicit import of a module must not mark it as globally visited:
+    // a later star import of the same module in the same pass still has to
+    // pick up the module's transitively re-exported fixtures.
+    let db = FixtureDatabase::new();
+    let base = std::env::temp_dir().join("pls_explicit_then_star");
+
+    let module_c = base.join("module_c.py");
+    db.analyze_file(
+        module_c.clone(),
+        "import pytest\n\n@pytest.fixture\ndef transitive_fix():\n    return 1\n",
+    );
+
+    let module_a = base.join("module_a.py");
+    db.analyze_file(
+        module_a.clone(),
+        "from module_c import *\n\nimport pytest\n\n@pytest.fixture\ndef direct_fix():\n    return 2\n",
+    );
+
+    let conftest = base.join("conftest.py");
+    db.analyze_file(
+        conftest.clone(),
+        "from module_a import direct_fix\nfrom module_a import *\n",
+    );
+
+    let mut visited = HashSet::new();
+    let imported = db.get_imported_fixtures(&conftest, &mut visited);
+    assert!(
+        imported.contains_key("direct_fix"),
+        "explicitly imported fixture must be found, got {:?}",
+        imported.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        imported.get("transitive_fix"),
+        Some(&module_c),
+        "star import must still surface module_a's transitive re-exports"
+    );
+}

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -15217,7 +15217,7 @@ fn test_completion_context_text_fallback_fixture_scope_single_quotes() {
 #[timeout(120000)]
 fn test_file_cache_eviction_bounds_cache_size() {
     let db = FixtureDatabase::new();
-    let base = PathBuf::from("/tmp/pls_eviction_test");
+    let base = std::env::temp_dir().join("pls_eviction_test");
 
     // MAX_FILE_CACHE_SIZE is 2000; exceed it enough to trigger bulk eviction.
     let total = 2101;
@@ -15258,4 +15258,36 @@ fn test_file_cache_eviction_bounds_cache_size() {
         }
     }
     assert!(evicted > 0, "expected at least one eviction");
+}
+
+#[test]
+#[timeout(30000)]
+fn test_explicit_import_resolves_to_reexporting_source() {
+    // conftest explicitly imports a fixture from module B, which itself
+    // star-imports it from module C. The imported-fixtures map must attribute
+    // the fixture to its true source (module C).
+    let db = FixtureDatabase::new();
+    let base = std::env::temp_dir().join("pls_reexport_source");
+
+    let module_c = base.join("module_c.py");
+    db.analyze_file(
+        module_c.clone(),
+        "import pytest\n\n@pytest.fixture\ndef reexported_fix():\n    return 1\n",
+    );
+
+    let module_b = base.join("module_b.py");
+    db.analyze_file(module_b.clone(), "from module_c import *\n");
+
+    let conftest = base.join("conftest.py");
+    db.analyze_file(conftest.clone(), "from module_b import reexported_fix\n");
+
+    let mut visited = HashSet::new();
+    let imported = db.get_imported_fixtures(&conftest, &mut visited);
+    let source = imported
+        .get("reexported_fix")
+        .expect("explicitly imported re-exported fixture must be found");
+    assert_eq!(
+        source, &module_c,
+        "the fixture must be attributed to the file that defines it"
+    );
 }

--- a/tests/test_language_server.rs
+++ b/tests/test_language_server.rs
@@ -22,15 +22,7 @@ fn make_backend_with_db(db: Arc<FixtureDatabase>) -> Backend {
     let slot_clone = slot.clone();
     let (_svc, _sock) = LspService::new(move |client| {
         let b = Backend::new(client, db.clone());
-        *slot_clone.lock().unwrap() = Some(Backend {
-            client: b.client.clone(),
-            fixture_db: b.fixture_db.clone(),
-            workspace_root: b.workspace_root.clone(),
-            original_workspace_root: b.original_workspace_root.clone(),
-            scan_task: b.scan_task.clone(),
-            uri_cache: b.uri_cache.clone(),
-            config: b.config.clone(),
-        });
+        *slot_clone.lock().unwrap() = Some(b.clone());
         b
     });
     let backend = slot.lock().unwrap().take().expect("backend created");

--- a/tests/test_language_server.rs
+++ b/tests/test_language_server.rs
@@ -2402,8 +2402,11 @@ async fn test_did_change_debounce_publishes_after_quiet_period() {
         })
         .await;
 
-    // Two rapid changes: the first debounce task must be superseded by the
-    // second (covers the early-return path), the second must publish.
+    // Two rapid changes bump the generation twice; the assertion below pins
+    // the synchronous generation bookkeeping. The sleep then lets both
+    // debounce tasks run: the first is superseded (early-return path) and
+    // the second publishes — exercised for coverage, observable effects go
+    // to the mock client.
     backend
         .did_change(did_change_params(
             uri.clone(),
@@ -2452,8 +2455,9 @@ async fn test_did_close_while_debounce_pending_clears_generation() {
         ))
         .await;
 
-    // Close while the debounce task is still pending: the generation entry is
-    // dropped, so the task must re-clear instead of leaving stale diagnostics.
+    // Close while the debounce task is still sleeping: did_close drops the
+    // generation entry synchronously (asserted below) and the pending task
+    // early-returns on the mismatch when it wakes during the sleep.
     backend
         .did_close(DidCloseTextDocumentParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },

--- a/tests/test_language_server.rs
+++ b/tests/test_language_server.rs
@@ -2266,3 +2266,205 @@ async fn test_publish_diagnostics_clean_file_publishes_nothing() {
         .publish_diagnostics_for_file(&conftest_uri, &conftest_path)
         .await;
 }
+
+// ── Position-encoding negotiation ────────────────────────────────────────
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_initialize_negotiates_utf8_when_client_supports_it() {
+    let backend = make_backend();
+    let params = InitializeParams {
+        capabilities: ClientCapabilities {
+            general: Some(GeneralClientCapabilities {
+                position_encodings: Some(vec![
+                    PositionEncodingKind::UTF8,
+                    PositionEncodingKind::UTF16,
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = backend.initialize(params).await.unwrap();
+    assert_eq!(
+        result.capabilities.position_encoding,
+        Some(PositionEncodingKind::UTF8)
+    );
+    assert!(!backend
+        .client_utf16
+        .load(std::sync::atomic::Ordering::Relaxed));
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_initialize_defaults_to_utf16_encoding() {
+    let backend = make_backend();
+    let result = backend
+        .initialize(InitializeParams::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        result.capabilities.position_encoding,
+        Some(PositionEncodingKind::UTF16)
+    );
+    assert!(backend
+        .client_utf16
+        .load(std::sync::atomic::Ordering::Relaxed));
+}
+
+// ── Multi-root workspaces ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_initialize_scans_all_workspace_folders() {
+    use std::fs;
+
+    let db = Arc::new(FixtureDatabase::new());
+    let backend = make_backend_with_db(Arc::clone(&db));
+
+    let base = std::env::temp_dir().join("test_ls_multi_root");
+    let root_a = base.join("root_a");
+    let root_b = base.join("root_b");
+    fs::create_dir_all(&root_a).unwrap();
+    fs::create_dir_all(&root_b).unwrap();
+    fs::write(
+        root_a.join("conftest.py"),
+        "import pytest\n\n@pytest.fixture\ndef fixture_root_a():\n    return 1\n",
+    )
+    .unwrap();
+    fs::write(
+        root_b.join("conftest.py"),
+        "import pytest\n\n@pytest.fixture\ndef fixture_root_b():\n    return 2\n",
+    )
+    .unwrap();
+
+    let params = InitializeParams {
+        workspace_folders: Some(vec![
+            WorkspaceFolder {
+                uri: Uri::from_file_path(&root_a).unwrap(),
+                name: "root_a".to_string(),
+            },
+            WorkspaceFolder {
+                uri: Uri::from_file_path(&root_b).unwrap(),
+                name: "root_b".to_string(),
+            },
+        ]),
+        ..Default::default()
+    };
+
+    backend.initialize(params).await.unwrap();
+
+    // Wait for the background scan task to finish before asserting.
+    if let Some(handle) = backend.scan_task.lock().await.take() {
+        handle.await.unwrap();
+    }
+
+    assert!(
+        db.definitions.contains_key("fixture_root_a"),
+        "first workspace folder should be scanned"
+    );
+    assert!(
+        db.definitions.contains_key("fixture_root_b"),
+        "second workspace folder should be scanned"
+    );
+}
+
+// ── did_change debounce ───────────────────────────────────────────────────
+
+fn did_change_params(uri: Uri, version: i32, text: &str) -> DidChangeTextDocumentParams {
+    DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier { uri, version },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: text.to_string(),
+        }],
+    }
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_did_change_debounce_publishes_after_quiet_period() {
+    let db = Arc::new(FixtureDatabase::new());
+    let backend = make_backend_with_db(Arc::clone(&db));
+    let uri = turi("test_ls_debounce", "test_example.py");
+
+    backend
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: uri.clone(),
+                language_id: "python".to_string(),
+                version: 1,
+                text: "def test_a():\n    pass\n".to_string(),
+            },
+        })
+        .await;
+
+    // Two rapid changes: the first debounce task must be superseded by the
+    // second (covers the early-return path), the second must publish.
+    backend
+        .did_change(did_change_params(
+            uri.clone(),
+            2,
+            "def test_a():\n    x = 1\n",
+        ))
+        .await;
+    backend
+        .did_change(did_change_params(
+            uri.clone(),
+            3,
+            "def test_a():\n    x = 2\n",
+        ))
+        .await;
+
+    // Let the debounce window elapse so the pending task runs to completion.
+    tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+
+    let file_path = tfile("test_ls_debounce", "test_example.py");
+    let generation = backend.change_generation.get(&file_path).map(|g| *g);
+    assert_eq!(generation, Some(2), "both changes must bump the generation");
+}
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_did_close_while_debounce_pending_clears_generation() {
+    let db = Arc::new(FixtureDatabase::new());
+    let backend = make_backend_with_db(Arc::clone(&db));
+    let uri = turi("test_ls_debounce_close", "test_example.py");
+
+    backend
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: uri.clone(),
+                language_id: "python".to_string(),
+                version: 1,
+                text: "def test_a():\n    pass\n".to_string(),
+            },
+        })
+        .await;
+    backend
+        .did_change(did_change_params(
+            uri.clone(),
+            2,
+            "def test_a():\n    x = 1\n",
+        ))
+        .await;
+
+    // Close while the debounce task is still pending: the generation entry is
+    // dropped, so the task must re-clear instead of leaving stale diagnostics.
+    backend
+        .did_close(DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+        })
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+
+    let file_path = tfile("test_ls_debounce_close", "test_example.py");
+    assert!(
+        backend.change_generation.get(&file_path).is_none(),
+        "closed file must not retain a debounce generation entry"
+    );
+}

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -5924,15 +5924,7 @@ fn make_backend_with_db(
     let slot_clone = backend_slot.clone();
     let (_svc, _sock) = LspService::new(move |client| {
         let b = Backend::new(client, db.clone());
-        *slot_clone.lock().unwrap() = Some(Backend {
-            client: b.client.clone(),
-            fixture_db: b.fixture_db.clone(),
-            workspace_root: b.workspace_root.clone(),
-            original_workspace_root: b.original_workspace_root.clone(),
-            scan_task: b.scan_task.clone(),
-            uri_cache: b.uri_cache.clone(),
-            config: b.config.clone(),
-        });
+        *slot_clone.lock().unwrap() = Some(b.clone());
         b
     });
     let result = backend_slot
@@ -8416,5 +8408,64 @@ def test_something(my_fixture, foo):
     assert!(
         on_fixture.is_none(),
         "prepare_rename on a fixture param should be declined"
+    );
+}
+
+// ── Position-encoding integration tests ─────────────────────────────────
+
+#[tokio::test]
+async fn test_references_utf16_positions_on_non_ascii_line() {
+    // The client speaks UTF-16 (the default); columns sent and received must
+    // be UTF-16 code units even though internal storage is byte offsets.
+    use pytest_language_server::FixtureDatabase;
+
+    let db = Arc::new(FixtureDatabase::new());
+    let test_path = std::env::temp_dir()
+        .join("test_utf16_positions")
+        .join("test_example.py");
+    let content = "import pytest\n\n@pytest.fixture\ndef fixture_é():\n    return 1\n\ndef test_ünï(fixture_é):\n    assert fixture_é\n";
+    db.analyze_file(test_path.clone(), content);
+
+    let backend = make_backend_with_db(db);
+    let uri = Uri::from_file_path(&test_path).unwrap();
+
+    // Cursor inside `fixture_é` on `def test_ünï(fixture_é):` (0-based line 6).
+    // "def test_ünï(" is 13 UTF-16 units but 15 bytes (ü and ï are 2 bytes each).
+    let params = ReferenceParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            position: Position {
+                line: 6,
+                character: 14,
+            },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+        context: ReferenceContext {
+            include_declaration: true,
+        },
+    };
+
+    let locations = backend
+        .handle_references(params)
+        .await
+        .unwrap()
+        .expect("references should be found for fixture_é");
+
+    // The signature usage must come back in UTF-16 columns: the parameter
+    // starts at unit 13 and `fixture_é` is 9 units long → ends at 22.
+    // (In bytes it spans 15..25 — the old, wrong behaviour.)
+    let param_loc = locations
+        .iter()
+        .find(|l| l.range.start.line == 6)
+        .expect("expected a location on the signature line");
+    assert_eq!(param_loc.range.start.character, 13);
+    assert_eq!(param_loc.range.end.character, 22);
+
+    // The definition location (line 3) is also included per includeDeclaration.
+    assert!(
+        locations.iter().any(|l| l.range.start.line == 3),
+        "expected the definition location, got {:?}",
+        locations
     );
 }

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -8519,3 +8519,64 @@ async fn test_references_byte_positions_when_utf8_negotiated() {
     assert_eq!(param_loc.range.start.character, 15);
     assert_eq!(param_loc.range.end.character, 25);
 }
+
+#[tokio::test]
+#[timeout(30000)]
+async fn test_rename_parametrize_unicode_identifier() {
+    // Unicode parametrize parameter names are legal Python; both the cursor
+    // token extraction and the new-name validation must accept them.
+    // Run in utf-8 mode so positions in this test are byte offsets end to end.
+    use pytest_language_server::FixtureDatabase;
+    use tower_lsp_server::LanguageServer;
+
+    let content = r#"import pytest
+
+
+@pytest.mark.parametrize("café", ["a", "b"])
+def test_something(café):
+    print(café)
+"#;
+    let expected = r#"import pytest
+
+
+@pytest.mark.parametrize("renamed_ü", ["a", "b"])
+def test_something(renamed_ü):
+    print(renamed_ü)
+"#;
+
+    let db = Arc::new(FixtureDatabase::new());
+    let path = std::env::temp_dir()
+        .join("test_rename_unicode")
+        .join("test_parametrize.py");
+    db.analyze_file(path.clone(), content);
+    let backend = make_backend_with_db(db);
+    backend
+        .client_utf16
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+    let uri = Uri::from_file_path(&path).unwrap();
+
+    // Cursor on the parameter in the signature (byte column of "café").
+    let sig_line = 4u32;
+    let byte_col = "def test_something(".len() as u32;
+    let ws = backend
+        .rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position {
+                    line: sig_line,
+                    character: byte_col,
+                },
+            },
+            new_name: "renamed_ü".to_string(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        })
+        .await
+        .expect("rename should not error")
+        .expect("unicode parametrize param should be renameable");
+
+    let edits = ws.changes.expect("rename should produce changes");
+    let edits = edits.into_values().next().expect("one file of edits");
+    assert_eq!(apply_text_edits(content, &edits), expected);
+}

--- a/tests/test_lsp.rs
+++ b/tests/test_lsp.rs
@@ -8469,3 +8469,53 @@ async fn test_references_utf16_positions_on_non_ascii_line() {
         locations
     );
 }
+
+#[tokio::test]
+async fn test_references_byte_positions_when_utf8_negotiated() {
+    // When the client negotiated utf-8, internal byte columns pass through
+    // unconverted in both directions.
+    use pytest_language_server::FixtureDatabase;
+
+    let db = Arc::new(FixtureDatabase::new());
+    let test_path = std::env::temp_dir()
+        .join("test_utf8_positions")
+        .join("test_example.py");
+    let content = "import pytest\n\n@pytest.fixture\ndef fixture_é():\n    return 1\n\ndef test_ünï(fixture_é):\n    assert fixture_é\n";
+    db.analyze_file(test_path.clone(), content);
+
+    let backend = make_backend_with_db(db);
+    backend
+        .client_utf16
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+    let uri = Uri::from_file_path(&test_path).unwrap();
+
+    // Byte column 16 is inside `fixture_é` ("def test_ünï(" is 15 bytes).
+    let params = ReferenceParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            position: Position {
+                line: 6,
+                character: 16,
+            },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+        context: ReferenceContext {
+            include_declaration: true,
+        },
+    };
+
+    let locations = backend
+        .handle_references(params)
+        .await
+        .unwrap()
+        .expect("references should be found for fixture_é");
+
+    // Outbound columns are byte offsets: 15..25 (`fixture_é` is 10 bytes).
+    let param_loc = locations
+        .iter()
+        .find(|l| l.range.start.line == 6)
+        .expect("expected a location on the signature line");
+    assert_eq!(param_loc.range.start.character, 15);
+    assert_eq!(param_loc.range.end.character, 25);
+}

--- a/tests/test_lsp_performance.rs
+++ b/tests/test_lsp_performance.rs
@@ -8,6 +8,7 @@
 use ntest::timeout;
 use pytest_language_server::FixtureDatabase;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 /// Helper to create a temporary test file with given content
@@ -791,4 +792,52 @@ def fixture_{n}():
             i
         );
     }
+}
+
+/// Concurrent re-analysis of the SAME file — the real contention surface for
+/// the shared definitions/usages maps (the older test only used distinct files).
+#[test]
+#[timeout(60000)]
+fn test_concurrent_same_file_modifications() {
+    let db = Arc::new(FixtureDatabase::new());
+    let path = PathBuf::from("/tmp/pls_concurrent_same/test_file.py");
+
+    const CONTENT_A: &str = "import pytest\n\n@pytest.fixture\ndef fix_a():\n    return 1\n\ndef test_x(fix_a):\n    assert fix_a\n";
+    const CONTENT_B: &str = "import pytest\n\n@pytest.fixture\ndef fix_b():\n    return 2\n\ndef test_x(fix_b):\n    assert fix_b\n";
+
+    let mut handles = Vec::new();
+    for t in 0..8usize {
+        let db = Arc::clone(&db);
+        let path = path.clone();
+        handles.push(std::thread::spawn(move || {
+            for i in 0..50usize {
+                let content = if (t + i) % 2 == 0 {
+                    CONTENT_A
+                } else {
+                    CONTENT_B
+                };
+                db.analyze_file(path.clone(), content);
+                // Interleave reads that take guards on the same maps.
+                let _ = db.find_fixture_references("fix_a");
+                let _ = db.get_available_fixtures(&path);
+                let _ = db.get_undeclared_fixtures(&path);
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("no thread should panic or deadlock");
+    }
+
+    // A final serial analysis must restore a fully consistent state.
+    db.analyze_file(path.clone(), CONTENT_A);
+    assert!(db.definitions.contains_key("fix_a"));
+    let stale_b = db
+        .definitions
+        .get("fix_b")
+        .map(|defs| defs.iter().any(|d| d.file_path == path))
+        .unwrap_or(false);
+    assert!(
+        !stale_b,
+        "fix_b must be cleaned up after the final analysis"
+    );
 }

--- a/tests/test_lsp_performance.rs
+++ b/tests/test_lsp_performance.rs
@@ -800,7 +800,9 @@ def fixture_{n}():
 #[timeout(60000)]
 fn test_concurrent_same_file_modifications() {
     let db = Arc::new(FixtureDatabase::new());
-    let path = PathBuf::from("/tmp/pls_concurrent_same/test_file.py");
+    let path = std::env::temp_dir()
+        .join("pls_concurrent_same")
+        .join("test_file.py");
 
     const CONTENT_A: &str = "import pytest\n\n@pytest.fixture\ndef fix_a():\n    return 1\n\ndef test_x(fix_a):\n    assert fix_a\n";
     const CONTENT_B: &str = "import pytest\n\n@pytest.fixture\ndef fix_b():\n    return 2\n\ndef test_x(fix_b):\n    assert fix_b\n";


### PR DESCRIPTION
Fixes from a full review of the server, grouped into four commits.

**Positions.** The server sent byte columns while clients default to UTF-16, so every feature mis-positioned on lines containing non-ASCII text. It now negotiates utf-8 when the client offers it and converts between byte and UTF-16 columns at the provider boundary otherwise.

**Resolver.** Imported fixtures resolve to the file their import points at instead of the first same-named definition. usefixtures/parametrize string ranges handle prefixes (`r"..."`) and triple quotes. Async generator fixtures yielding inside `async with`/`async for` report the yielded type instead of the full `AsyncGenerator[...]`. Undeclared-fixture scanning covers f-strings, ternaries, boolops, comprehension iterables, `try`/`raise`/`match`, annotated assignments and walrus bindings.

**LSP behaviour.** `did_change` diagnostics are debounced (200ms) so rapid keystrokes coalesce. All workspace folders are scanned, not just the first. Diagnostics are cleared on `did_close`. The "N usages" code lens works now: its command was never registered by any client, so the VSCode extension implements it. musl and unsupported Linux architectures get a clear error instead of a silently wrong glibc x86_64 binary. Only the first quickfix is marked preferred, and rename accepts legal Unicode identifiers.

**Performance.** `get_available_fixtures` returns its cached `Arc` instead of deep-cloning per request, and available fixtures are computed in a single ranked pass instead of one full scan per ancestor directory. Analysis now populates the AST and import-map caches, so follow-up requests stop re-parsing. Disk reads are cached, references use the reverse index, per-file requests use the `file_definitions` index, and eviction never drops the file just analyzed.

**CI.** Publishing jobs (PyPI, crates.io, marketplaces, Homebrew) now depend on a test+clippy gate; `publish-crates` previously had no `needs:` at all and used `--allow-dirty`. `npm ci` replaces `npm install` so builds respect the lockfile.

The `fixture_paths` and `skip_plugins` config keys log a warning instead of being silently ignored, and the README marks them as not implemented. `once_cell` was replaced with `std::sync::LazyLock` (MSRV is 1.85) and a release profile (lto, codegen-units=1, strip) was added.

Tests grew from 1293 to 1313: UTF-16 conversion units, an end-to-end references test on non-ASCII content, cache eviction bounds (2101 files), concurrent same-file analysis, and regressions for each parser fix. One deliberate shape change: import-merge edits now replace whole lines (end position at column 0 of the next line), which makes them encoding-independent; the merge tests were updated accordingly.

**Release note.** This changes public crate signatures (`get_available_fixtures` returns `Arc<Vec<_>>`, `get_imported_fixtures` returns `HashMap<String, PathBuf>`, `is_fixture_imported_in_file` removed, the `decorators` extractors gained a `content` parameter), so the next crates.io publish needs a version bump to 0.24.0 (`./bump-version.sh`). No in-repo or extension code is affected.
